### PR TITLE
Pure policy and value players

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -46,6 +46,7 @@ class ReplayBuffer:
         path: pathlib.Path | None = None,
     ):
         self.max_size = max_size
+        self.game_states = [None] * max_size
         self.spatial_input_buffer = np.empty(
             (max_size, *spatial_input_shape), dtype=np.float32
         )
@@ -95,6 +96,7 @@ class ReplayBuffer:
         buffer_index = self.count
         if self.count >= self.max_size:
             buffer_index = self.count % self.max_size
+        self.game_states[buffer_index] = game_state
         self.spatial_input_buffer[buffer_index] = skynet.get_spatial_state_numpy(
             game_state
         )

--- a/skynet.py
+++ b/skynet.py
@@ -692,17 +692,23 @@ class EquivariantSkyNet(nn.Module):
             torch.randn(1, 1, self.embedding_dimensions)
         )
 
-        # self.column_attention = TransformerBlock(
-        #     embed_dim=self.embedding_dimensions,
-        #     num_heads=self.num_heads,
-        #     mlp_ratio=None,
-        #     dropout=0.0,
-        # )
-        self.column_attention = ResidualAttentionBlock(
+        self.column_attention = TransformerBlock(
             embed_dim=self.embedding_dimensions,
             num_heads=self.num_heads,
+            mlp_ratio=None,
             dropout=0.0,
         )
+        self.column_attention2 = TransformerBlock(
+            embed_dim=self.embedding_dimensions,
+            num_heads=self.num_heads,
+            mlp_ratio=None,
+            dropout=0.0,
+        )
+        # self.column_attention = ResidualAttentionBlock(
+        #     embed_dim=self.embedding_dimensions,
+        #     num_heads=self.num_heads,
+        #     dropout=0.0,
+        # )
         # self.board_summary_token = nn.Parameter(
         #     torch.randn(1, 1, self.embedding_dimensions)
         # )

--- a/train.py
+++ b/train.py
@@ -172,15 +172,18 @@ def learn(
 
         # Add training data from the queue into the buffer
         logging.info(f"[LEARN] Generating {games_generated_per_iteration} games")
+        data_points = 0
         while (
             not training_data_queue.empty()
             or games_count - previous_games_count < games_generated_per_iteration
         ):
             game_data = training_data_queue.get()
             training_data_buffer.add_game_data(game_data)
+            data_points += len(game_data)
             games_count += 1
         logging.info(
             f"[LEARN] Finished generating {games_count - previous_games_count} games "
+            f"with {data_points} data points"
         )
         logging.info(
             f"[LEARN] Training data buffer length: {len(training_data_buffer)}, "


### PR DESCRIPTION
Adds a pure policy and value based players and uses these in model faceoffs to evaluate model strength. Note these are preferable to just using model players as using MCTS to run faceoffs is computationally expensive and these "pure" players are able to player games much faster.