### PR TITLE
Selfplay game statistics

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -92,6 +92,7 @@ class ReplayBuffer:
         outcome_target: np.ndarray,
         points_target: np.ndarray,
         policy_target: np.ndarray,
+        action_mask: np.ndarray,
     ):
         buffer_index = self.count
         if self.count >= self.max_size:
@@ -103,7 +104,7 @@ class ReplayBuffer:
         self.non_spatial_input_buffer[buffer_index] = (
             skynet.get_non_spatial_state_numpy(game_state)
         )
-        self.action_masks[buffer_index] = sj.actions(game_state).astype(np.float32)
+        self.action_masks[buffer_index] = action_mask
         self.policy_target_buffer[buffer_index] = policy_target
         self.outcome_target_buffer[buffer_index] = outcome_target
         self.points_target_buffer[buffer_index] = points_target
@@ -112,12 +113,28 @@ class ReplayBuffer:
     def add_game_data(self, game_data: play.GameData):
         """Adds a game's worth of training data to the buffer."""
 
-        for game_state, outcome_target, points_target, policy_target, _ in game_data:
-            self.add(game_state, outcome_target, points_target, policy_target)
+        for (
+            game_state,
+            outcome_target,
+            points_target,
+            policy_target,
+            action_mask,
+            _,
+        ) in game_data:
+            self.add(
+                game_state, outcome_target, points_target, policy_target, action_mask
+            )
 
     def add_game_data_with_symmetry(self, game_data: play.GameData):
         """Adds a game's worth of training data to the buffer."""
-        for game_state, outcome_target, points_target, policy_target, _ in game_data:
+        for (
+            game_state,
+            outcome_target,
+            points_target,
+            policy_target,
+            action_mask,
+            _,
+        ) in game_data:
             for (
                 symmetric_game_state,
                 symmetric_policy_target,
@@ -127,6 +144,7 @@ class ReplayBuffer:
                     outcome_target,
                     points_target,
                     symmetric_policy_target,
+                    action_mask,
                 )
 
     def sample_element(self) -> train_utils.TrainingDataPoint:

--- a/main.py
+++ b/main.py
@@ -158,12 +158,15 @@ if __name__ == "__main__":
         epochs=5,
         batch_size=256,
         learn_rate=1e-3,
-        loss_function=train_utils.base_policy_value_loss,
+        loss_function=lambda model_outputs, targets: train_utils.base_policy_value_loss(
+            model_outputs, targets, value_scale=10.0
+        ),
     )
     learn_config = train.LearnConfig(
         torch_device=device,
         learn_steps=1000,
         games_generated_per_iteration=500,
+        loss_stats_function=train_utils.loss_details_summary,
         validation_interval=1,
         validation_function=lambda model: explain.validate_model(
             model, validation_batch

--- a/train.py
+++ b/train.py
@@ -172,26 +172,27 @@ def learn(
 
         # Add training data from the queue into the buffer
         logging.info(f"[LEARN] Generating {games_generated_per_iteration} games")
-        data_points = 0
+        game_stats_list = []
         while (
             not training_data_queue.empty()
-            or games_count - previous_games_count < games_generated_per_iteration
+            or len(game_stats_list) < games_generated_per_iteration
         ):
-            game_data = training_data_queue.get()
+            game_data, game_stats = training_data_queue.get()
             training_data_buffer.add_game_data(game_data)
-            data_points += len(game_data)
-            games_count += 1
+            game_stats_list.append(game_stats)
         logging.info(
-            f"[LEARN] Finished generating {games_count - previous_games_count} games "
-            f"with {data_points} data points"
+            f"[LEARN] Finished generating {len(game_stats_list) - previous_games_count} games "
+            f"with {sum([game_stats.game_length for game_stats in game_stats_list])} data points"
         )
         logging.info(
             f"[LEARN] Training data buffer length: {len(training_data_buffer)}, "
         )
         buffer_saved_path = training_data_buffer.save()
         logging.info(f"Saving training data buffer to {buffer_saved_path}")
-
-        previous_games_count = games_count
+        logging.info(
+            f"Generated game stats:\n{train_utils.game_stats_summary(game_stats_list)}"
+        )
+        previous_games_count = len(game_stats_list)
         logging.info(f"[LEARN] Training for {training_epochs} epochs")
         for i in range(training_epochs):
             training_stats = train_epoch(

--- a/train_utils.py
+++ b/train_utils.py
@@ -1,6 +1,7 @@
 import typing
 
 import numpy as np
+import pandas as pd
 import torch
 
 import play
@@ -33,6 +34,13 @@ TrainingTargets: typing.TypeAlias = tuple[
 
 
 # MARK: Data Helpers
+
+
+def game_stats_summary(game_stats_list: list[play.GameStats]) -> pd.DataFrame:
+    stats_df = pd.DataFrame.from_records(
+        [game_stats.to_record_dict() for game_stats in game_stats_list]
+    )
+    return stats_df.describe().T
 
 
 def game_data_to_training_batch(


### PR DESCRIPTION
Adds generated game statistics that provide more visibility into what the selfplay games are looking like. For example, scores, game length, frequency of move types, etc.

Additionally, adds ability to customize logged training data loss stats (currently used to show value and policy losses separately)