### PR TITLE
Surface all random events

### DIFF
--- a/bin/play_randomly.py
+++ b/bin/play_randomly.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import skyjo2.play as sj_play
+
+if __name__ == "__main__":
+    game_count = 0
+    for game in sj_play.play((sj_play.RandomPlayer(),) * 4):
+        game_count += 1
+    print(f"finished on turn {game.turn} in {game_count} iterations")

--- a/src/skyjo2/__init__.py
+++ b/src/skyjo2/__init__.py
@@ -217,10 +217,12 @@ def _with_shuffle(
 
 
 class State(IntEnum):
-    NULL = auto()
+    DEAL_FIRST_CARD = auto()
     REVEAL_SECOND_CARD = auto()
     DRAW_OR_REPLACE_WITH_DISCARD = auto()
     DISCARD_DRAW_AND_REVEAL_OR_REPLACE_WITH_DRAW = auto()
+    ENDED = auto()
+    FORFEITED = auto()
 
 
 class Game(NamedTuple):
@@ -280,14 +282,13 @@ class Game(NamedTuple):
     def final_scores(self) -> tuple[int, ...]:
         """Get player scores as if the current player ended the round."""
 
-        assert self.state == State.NULL
+        assert self.state in {State.ENDED, State.FORFEITED}
 
         scores = [player.hand_score for player in self.players]
-        forfeit = any(finger.is_hidden for finger in self.player.hand)
 
         # Penalize the round ender if they forfeited or didn't have the lowest
         # hand score across all players.
-        if forfeit or scores[0] > min(scores[1:]):
+        if self.state == State.FORFEITED or scores[0] > min(scores[1:]):
             scores[0] *= 2
 
         return tuple(scores)
@@ -314,12 +315,16 @@ class Game(NamedTuple):
         return (self.winner_index + self.turn) % len(self.players)
 
     @property
-    def is_finished(self) -> bool:
-        return self.state == State.NULL
+    def is_ended(self) -> bool:
+        return self.state == State.ENDED
 
     @property
-    def is_forfeit(self) -> bool:
-        return self.is_finished and any(finger.is_hidden for finger in self.player.hand)
+    def is_forfeited(self) -> bool:
+        return self.state == State.FORFEITED
+
+    @property
+    def is_ended_or_forfeited(self) -> bool:
+        return self.state in {State.ENDED, State.FORFEITED}
 
     # MARK: Construct
 
@@ -331,7 +336,7 @@ class Game(NamedTuple):
         player = Player(score=0, hand=(finger,) * HAND_ROWS * HAND_COLUMNS)
         return Game(
             turn=0,
-            state=State.NULL,
+            state=State.DEAL_FIRST_CARD,
             drawn_card_index=None,
             draw_pile=tuple(DECK.values()),
             discarded_card_index=None,
@@ -354,7 +359,7 @@ class Game(NamedTuple):
         del self
 
         assert turn == 0
-        assert state == State.NULL
+        assert state == State.DEAL_FIRST_CARD
         assert drawn_card_index is None
         assert discarded_card_index is None
 
@@ -399,7 +404,7 @@ class Game(NamedTuple):
         del self
 
         assert turn == 0
-        assert state == State.NULL
+        assert state == State.DEAL_FIRST_CARD
         assert drawn_card_index is None
         assert discarded_card_index is None
 
@@ -598,7 +603,7 @@ class Game(NamedTuple):
         # Check if the current player won. If so, stop the game. Otherwise,
         # rotate players so the next is in the first slot.
         if players[0].is_hand_revealed:
-            state = State.NULL
+            state = State.ENDED
         else:
             players = (*players[1:], players[0])
             state = State.DRAW_OR_REPLACE_WITH_DISCARD
@@ -689,7 +694,7 @@ class Game(NamedTuple):
         # Check if the current player won. If so, stop the game. Otherwise,
         # rotate players so the next is in the first slot.
         if players[0].is_hand_revealed:
-            state = State.NULL
+            state = State.ENDED
         else:
             players = (*players[1:], players[0])
             state = State.DRAW_OR_REPLACE_WITH_DISCARD
@@ -776,7 +781,7 @@ class Game(NamedTuple):
         # Check if the current player won. If so, stop the game. Otherwise,
         # rotate players so the next is in the first slot.
         if players[0].is_hand_revealed:
-            state = State.NULL
+            state = State.ENDED
         else:
             players = (*players[1:], players[0])
             state = State.DRAW_OR_REPLACE_WITH_DISCARD
@@ -812,7 +817,7 @@ class Game(NamedTuple):
 
         return Game(
             turn=self.turn,
-            state=State.NULL,
+            state=State.FORFEITED,
             drawn_card_index=self.drawn_card_index,
             draw_pile=self.draw_pile,
             discarded_card_index=self.discarded_card_index,
@@ -834,9 +839,8 @@ class Game(NamedTuple):
         players = self.players
         del self
 
-        assert state == State.NULL
+        assert state in {State.ENDED, State.FORFEITED}
         assert drawn_card_index is None
-        assert players[0].hand_hidden_count == 0
 
         mutable_draw_pile = list(draw_pile)
         del draw_pile
@@ -873,9 +877,8 @@ class Game(NamedTuple):
         players = self.players
         del self
 
-        assert state == State.NULL
+        assert state in {State.ENDED, State.FORFEITED}
         assert drawn_card_index is None
-        assert players[0].hand_hidden_count == 0
 
         mutable_draw_pile = list(draw_pile)
         del draw_pile

--- a/src/skyjo2/__init__.py
+++ b/src/skyjo2/__init__.py
@@ -41,7 +41,7 @@ class Finger(NamedTuple):
 
     @property
     def is_cleared(self) -> bool:
-        return self.card_index is None
+        return self.is_revealed and self.card_index is None
 
     @property
     def is_hidden(self) -> bool:
@@ -155,7 +155,7 @@ class Player(NamedTuple):
         return Player(score=self.score, hand=hand)
 
 
-def pick_random_index(pile: Sequence[int], rng: random.Random = random) -> int:
+def _pick_random_index(pile: Sequence[int], rng: random.Random = random) -> int:
     needle = rng.randint(0, sum(pile) - 1)
     for index, haystack in enumerate(pile):
         if needle < haystack:
@@ -164,13 +164,32 @@ def pick_random_index(pile: Sequence[int], rng: random.Random = random) -> int:
     assert False
 
 
-def with_draw(pile: Sequence[int], index: int) -> tuple[int, ...]:
-    assert pile[index] > 0
-    return (*pile[:index], pile[index] - 1, *pile[index + 1 :])
+def _with_draw(draw_pile: Sequence[int], card_index: int) -> tuple[int, ...]:
+    assert draw_pile[card_index] > 0
+    return (
+        *draw_pile[:card_index],
+        draw_pile[card_index] - 1,
+        *draw_pile[card_index + 1 :],
+    )
 
 
-def with_discard(pile: Sequence[int], index: int) -> tuple[int, ...]:
-    return (*pile[:index], pile[index] + 1, *pile[index + 1 :])
+def _with_discard(discard_pile: Sequence[int], card_index: int) -> tuple[int, ...]:
+    return (
+        *discard_pile[:card_index],
+        discard_pile[card_index] + 1,
+        *discard_pile[card_index + 1 :],
+    )
+
+
+def _with_shuffle(
+    draw_pile: tuple[int],
+    discard_pile: tuple[int],
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    if sum(draw_pile) == 0:
+        assert sum(discard_pile) > 0
+        draw_pile = discard_pile
+        discard_pile = (0,) * len(discard_pile)
+    return draw_pile, discard_pile
 
 
 class State(IntEnum):
@@ -186,7 +205,7 @@ class Game(NamedTuple):
     turn: int
     """The number of turns that have been played, i.e. the turn index."""
 
-    state: int | None
+    state: State
     """The current state of the game."""
 
     drawn_card_index: int | None
@@ -283,17 +302,29 @@ class Game(NamedTuple):
         )
 
     def with_deal(self, card_indices: Iterable[int]) -> Game:
-        assert self.turn == 0
-        assert self.state == State.NULL
-        assert self.drawn_card_index is None
-        assert self.discarded_card_index is None
+        (
+            turn,
+            state,
+            drawn_card_index,
+            draw_pile,
+            discarded_card_index,
+            discard_pile,
+            players,
+        ) = self
+        del self
 
-        draw_pile = list(self.draw_pile)
+        assert turn == 0
+        assert state == State.NULL
+        assert drawn_card_index is None
+        assert discarded_card_index is None
+
+        mutable_draw_pile = list(draw_pile)
+        del draw_pile
 
         def deal_card_index_from_draw_pile() -> Iterator[int]:
             for card_index in card_indices:
-                assert draw_pile[card_index] > 0
-                draw_pile[card_index] -= 1
+                assert mutable_draw_pile[card_index] > 0
+                mutable_draw_pile[card_index] -= 1
                 yield card_index
 
         dealer = deal_card_index_from_draw_pile()
@@ -301,34 +332,45 @@ class Game(NamedTuple):
         # Exhaust the draw pile before we snapshot it as a `tuple` below.
         discarded_card_index = next(dealer)
         players = tuple(
-            player.with_deal(card_index)
-            for player, card_index in zip(self.players, dealer)
+            player.with_deal(card_index) for player, card_index in zip(players, dealer)
         )
 
         return Game(
-            turn=self.turn,
+            turn=turn,
             state=State.REVEAL_SECOND_CARD,
             drawn_card_index=None,
-            draw_pile=tuple(draw_pile),
+            draw_pile=tuple(mutable_draw_pile),
             discarded_card_index=discarded_card_index,
-            discard_pile=self.discard_pile,
+            discard_pile=discard_pile,
             players=players,
         )
 
     def with_random_deal(self, rng: random.Random = random) -> Game:
         """Deal players and set an initial discard."""
 
-        assert self.turn == 0
-        assert self.state == State.NULL
-        assert self.drawn_card_index is None
-        assert self.discarded_card_index is None
+        (
+            turn,
+            state,
+            drawn_card_index,
+            draw_pile,
+            discarded_card_index,
+            discard_pile,
+            players,
+        ) = self
+        del self
 
-        draw_pile = list(self.draw_pile)
+        assert turn == 0
+        assert state == State.NULL
+        assert drawn_card_index is None
+        assert discarded_card_index is None
+
+        mutable_draw_pile = list(draw_pile)
+        del draw_pile
 
         def deal_card_index_from_draw_pile() -> Iterator[int]:
             while True:
-                deal_card_index = pick_random_index(draw_pile, rng=rng)
-                draw_pile[deal_card_index] -= 1
+                deal_card_index = _pick_random_index(mutable_draw_pile, rng=rng)
+                mutable_draw_pile[deal_card_index] -= 1
                 yield deal_card_index
 
         dealer = deal_card_index_from_draw_pile()
@@ -336,33 +378,47 @@ class Game(NamedTuple):
         # Exhaust the draw pile before we snapshot it as a `tuple` below.
         discarded_card_index = next(dealer)
         players = tuple(
-            player.with_deal(card_index)
-            for player, card_index in zip(self.players, dealer)
+            player.with_deal(card_index) for player, card_index in zip(players, dealer)
         )
 
         return Game(
-            turn=self.turn,
+            turn=turn,
             state=State.REVEAL_SECOND_CARD,
             drawn_card_index=None,
-            draw_pile=tuple(draw_pile),
+            draw_pile=tuple(mutable_draw_pile),
             discarded_card_index=discarded_card_index,
-            discard_pile=self.discard_pile,
+            discard_pile=discard_pile,
             players=players,
         )
 
-    def with_second_card_revealed(self, finger_index: int, card_index: int) -> Game:
+    def with_second_card_revealed(
+        self,
+        finger_index: int,
+        revealed_card_index: int,
+    ) -> Game:
         """Reveal a second card during initial board setup."""
 
-        assert self.state == State.REVEAL_SECOND_CARD
+        (
+            turn,
+            state,
+            drawn_card_index,
+            draw_pile,
+            discarded_card_index,
+            discard_pile,
+            players,
+        ) = self
+        del self
+
+        assert state == State.REVEAL_SECOND_CARD
 
         # Formally draw the card we're revealing.
-        draw_pile = with_draw(self.draw_pile, card_index)
+        draw_pile = _with_draw(draw_pile, revealed_card_index)
 
         # Reveal the requested card.
-        assert self.players[0].hand[finger_index].is_hidden
+        assert players[0].hand[finger_index].is_hidden
         players = (
-            self.players[0].with_card(finger_index, card_index),
-            *self.players[1:],
+            players[0].with_card(finger_index, revealed_card_index),
+            *players[1:],
         )
 
         # Rotate players. Left separate from reveal for clarity.
@@ -370,8 +426,7 @@ class Game(NamedTuple):
 
         # Check if we're done revealing cards. If we are, we need to skip turns
         # until we've reached the player who revealed the lowest cards.
-        turn = self.turn + 1
-        state = self.state
+        turn += 1
         if turn == len(players):
             state = State.DRAW_OR_REPLACE_WITH_DISCARD
             turn += min(
@@ -382,77 +437,120 @@ class Game(NamedTuple):
         return Game(
             turn=turn,
             state=state,
-            drawn_card_index=self.drawn_card_index,
+            drawn_card_index=drawn_card_index,
             draw_pile=draw_pile,
-            discarded_card_index=self.discarded_card_index,
-            discard_pile=self.discard_pile,
+            discarded_card_index=discarded_card_index,
+            discard_pile=discard_pile,
             players=players,
+        )
+
+    def with_random_second_card_revealed(
+        self,
+        finger_index: int,
+        rng: random.Random = random,
+    ) -> Game:
+        """Pick a random card from the draw pile to reveal."""
+
+        return self.with_second_card_revealed(
+            finger_index,
+            _pick_random_index(self.draw_pile, rng=rng),
         )
 
     def with_drawn_card(self, drawn_card_index: int) -> Game:
         """Draw a specific card from the pile but do nothing with it."""
 
-        assert self.state == State.DRAW_OR_REPLACE_WITH_DISCARD
-        assert self.drawn_card_index is None
-        assert sum(self.draw_pile) > 0
+        (
+            turn,
+            state,
+            drawn_card_index,
+            draw_pile,
+            discarded_card_index,
+            discard_pile,
+            players,
+        ) = self
+        del self
+
+        assert state == State.DRAW_OR_REPLACE_WITH_DISCARD
+        assert drawn_card_index is None
+        assert sum(draw_pile) > 0
 
         # Remove the drawn card from the draw pile.
-        draw_pile = with_draw(self.draw_pile, drawn_card_index)
+        draw_pile = _with_draw(draw_pile, drawn_card_index)
 
         # Shuffle the discards into the draw pile if there are no more draws.
         # Always do this at the end of states, if possible, so we don't have
         # to juggle reshuffles before draws.
-        discard_pile = self.discard_pile
-        if sum(draw_pile) == 0:
-            assert sum(discard_pile) > 0
-            draw_pile = discard_pile
-            discard_pile = (0,) * len(discard_pile)
+        draw_pile, discard_pile = _with_shuffle(draw_pile, discard_pile)
 
         return Game(
-            turn=self.turn,
+            turn=turn,
             state=State.DISCARD_DRAW_AND_REVEAL_OR_REPLACE_WITH_DRAW,
             drawn_card_index=drawn_card_index,
             draw_pile=draw_pile,
-            discarded_card_index=self.discarded_card_index,
+            discarded_card_index=discarded_card_index,
             discard_pile=discard_pile,
-            players=self.players,
+            players=players,
         )
 
     def with_random_drawn_card(self, rng: random.Random = random) -> Game:
         """Draw a random card from the pile but do nothing with it."""
 
-        drawn_card_index = pick_random_index(self.draw_pile, rng=rng)
+        drawn_card_index = _pick_random_index(self.draw_pile, rng=rng)
         return self.with_drawn_card(drawn_card_index)
 
-    def with_draw_discarded_and_card_revealed(self, finger_index: int) -> Game:
+    def with_draw_discarded_and_card_revealed(
+        self,
+        finger_index: int,
+        revealed_card_index: int,
+    ) -> Game:
         """Discard the drawn card and reveal a card in the current hand."""
 
-        assert self.state == State.DISCARD_DRAW_AND_REVEAL_OR_REPLACE_WITH_DRAW
-        assert self.drawn_card_index is not None
-        assert self.discarded_card_index is not None
+        (
+            turn,
+            state,
+            drawn_card_index,
+            draw_pile,
+            discarded_card_index,
+            discard_pile,
+            players,
+        ) = self
+        del self
+
+        assert state == State.DISCARD_DRAW_AND_REVEAL_OR_REPLACE_WITH_DRAW
+        assert drawn_card_index is not None
+        assert discarded_card_index is not None
+        assert players[0].hand[finger_index].is_hidden
 
         # Put the current discarded card into the pile.
-        discard_pile = with_discard(self.discard_pile, self.discarded_card_index)
+        discard_pile = _with_discard(discard_pile, discarded_card_index)
 
         # Move the drawn card to be the discarded card.
-        discarded_card_index = self.drawn_card_index
+        discarded_card_index = drawn_card_index
         drawn_card_index = None
+
+        # Formally draw the revealed card.
+        draw_pile = _with_draw(draw_pile, revealed_card_index)
 
         # Reveal the requested card.
-        card_index = self.players[0].hand[finger_index].card_index
+        card_index = players[0].hand[finger_index].card_index
         players = (
-            self.players[0].with_revealed_card(finger_index),
-            *self.players[1:],
+            players[0].with_card(finger_index, revealed_card_index),
+            *players[1:],
         )
 
         # If the card got cleared, we need to replace the current discarded
         # card and update the discard pile. This is a little wasteful but we'll
         # wait to profile before we inline it since it's rare.
         if players[0].hand[finger_index].is_cleared:
-            discard_pile = with_discard(discard_pile, discarded_card_index)
-            discard_pile = with_discard(discard_pile, card_index)
-            discard_pile = with_discard(discard_pile, card_index)
+            discard_pile = _with_discard(discard_pile, discarded_card_index)
+            discard_pile = _with_discard(discard_pile, card_index)
+            discard_pile = _with_discard(discard_pile, card_index)
             discarded_card_index = card_index
+
+        # Shuffle the discards into the draw pile if there are no more draws.
+        # Always do this at the end of states, if possible, so we don't have
+        # to juggle reshuffles before draws.
+        draw_pile, discard_pile = _with_shuffle(draw_pile, discard_pile)
 
         # Check if the current player won. If so, stop the game. Otherwise,
         # rotate players so the next is in the first slot.
@@ -463,43 +561,84 @@ class Game(NamedTuple):
             state = State.DRAW_OR_REPLACE_WITH_DISCARD
 
         return Game(
-            turn=self.turn + 1,
+            turn=turn + 1,
             state=state,
             drawn_card_index=drawn_card_index,
-            draw_pile=self.draw_pile,
+            draw_pile=draw_pile,
             discarded_card_index=discarded_card_index,
             discard_pile=discard_pile,
             players=players,
         )
 
-    def with_card_replaced_with_draw(self, finger_index: int) -> Game:
+    def with_draw_discarded_and_random_card_revealed(
+        self,
+        finger_index: int,
+        rng: random.Random = random,
+    ) -> Game:
+        """Pick a random card from the draw pile to reveal."""
+
+        return self.with_draw_discarded_and_card_revealed(
+            finger_index,
+            _pick_random_index(self.draw_pile, rng=rng),
+        )
+
+    def with_card_replaced_with_draw(
+        self,
+        finger_index: int,
+        revealed_card_index: int | None,  # only if finger is hidden
+    ) -> Game:
         """Replace a card in the current hand with the drawn card."""
 
-        assert self.state == State.DISCARD_DRAW_AND_REVEAL_OR_REPLACE_WITH_DRAW
-        assert self.drawn_card_index is not None
+        (
+            turn,
+            state,
+            drawn_card_index,
+            draw_pile,
+            discarded_card_index,
+            discard_pile,
+            players,
+        ) = self
+        del self
+
+        assert state == State.DISCARD_DRAW_AND_REVEAL_OR_REPLACE_WITH_DRAW
+        assert drawn_card_index is not None
 
         # Put the current discarded card into the pile.
-        discard_pile = with_discard(self.discard_pile, self.discarded_card_index)
+        discard_pile = _with_discard(discard_pile, discarded_card_index)
 
-        # Move the replaced card to be the new discarded card.
-        discarded_card_index = self.players[0].hand[finger_index].card_index
+        # Move the replaced card to be the new discarded card. If the card was
+        # hidden, it needs to be formally drawn.
+        finger = players[0].hand[finger_index]
+        discarded_card_index = finger.card_index
+        if discarded_card_index is None:
+            assert finger.is_hidden
+            assert revealed_card_index is not None
+            draw_pile = _with_draw(draw_pile, revealed_card_index)
+            discarded_card_index = revealed_card_index
+        else:
+            assert revealed_card_index is None
 
         # Replace the card in the player's hand.
-        card_index = self.drawn_card_index
+        card_index = drawn_card_index
         drawn_card_index = None
         players = (
-            self.players[0].with_replaced_card(finger_index, card_index),
-            *self.players[1:],
+            players[0].with_card(finger_index, card_index),
+            *players[1:],
         )
 
         # If the card got cleared, we need to replace the current discarded
         # card and update the discard pile. This is a little wasteful but we'll
         # wait to profile before we inline it since it's rare.
         if players[0].hand[finger_index].is_cleared:
-            discard_pile = with_discard(discard_pile, discarded_card_index)
-            discard_pile = with_discard(discard_pile, card_index)
-            discard_pile = with_discard(discard_pile, card_index)
+            discard_pile = _with_discard(discard_pile, discarded_card_index)
+            discard_pile = _with_discard(discard_pile, card_index)
+            discard_pile = _with_discard(discard_pile, card_index)
             discarded_card_index = card_index
+
+        # Shuffle the discards into the draw pile if there are no more draws.
+        # Always do this at the end of states, if possible, so we don't have
+        # to juggle reshuffles before draws.
+        draw_pile, discard_pile = _with_shuffle(draw_pile, discard_pile)
 
         # Check if the current player won. If so, stop the game. Otherwise,
         # rotate players so the next is in the first slot.
@@ -510,41 +649,83 @@ class Game(NamedTuple):
             state = State.DRAW_OR_REPLACE_WITH_DISCARD
 
         return Game(
-            turn=self.turn + 1,
+            turn=turn + 1,
             state=state,
             drawn_card_index=drawn_card_index,
-            draw_pile=self.draw_pile,
+            draw_pile=draw_pile,
             discarded_card_index=discarded_card_index,
             discard_pile=discard_pile,
             players=players,
         )
 
-    def with_card_replaced_with_discard(self, finger_index: int) -> Game:
+    def with_random_card_replaced_with_draw(
+        self,
+        finger_index: int,
+        rng: random.Random = random,
+    ) -> Game:
+        """Randomly pick if the replaced card is hidden."""
+
+        return self.with_card_replaced_with_draw(
+            finger_index,
+            _pick_random_index(self.draw_pile, rng=rng)
+            if self.players[0].hand[finger_index].is_hidden
+            else None,
+        )
+
+    def with_card_replaced_with_discard(
+        self,
+        finger_index: int,
+        revealed_card_index: int | None,
+    ) -> Game:
         """Replace a card in the current hand with the drawn card."""
 
-        assert self.state == State.DRAW_OR_REPLACE_WITH_DISCARD
-        assert self.drawn_card_index is None
+        (
+            turn,
+            state,
+            drawn_card_index,
+            draw_pile,
+            discarded_card_index,
+            discard_pile,
+            players,
+        ) = self
+        del self
 
-        discard_pile = self.discard_pile
+        assert state == State.DRAW_OR_REPLACE_WITH_DISCARD
+        assert drawn_card_index is None
 
         # Put the current discarded card into the pile.
-        card_index = self.discarded_card_index
-        discarded_card_index = self.players[0].hand[finger_index].card_index
+        # Move the replaced card to be the new discarded card. If the card was
+        # hidden, it needs to be formally drawn.
+        finger = players[0].hand[finger_index]
+        discarded_card_index = finger.card_index
+        if discarded_card_index is None:
+            assert finger.is_hidden
+            assert revealed_card_index is not None
+            draw_pile = _with_draw(draw_pile, revealed_card_index)
+            discarded_card_index = revealed_card_index
+        else:
+            assert revealed_card_index is None
 
         # Replace the card in the player's hand.
+        card_index = discarded_card_index
         players = (
-            self.players[0].with_replaced_card(finger_index, card_index),
-            *self.players[1:],
+            players[0].with_card(finger_index, card_index),
+            *players[1:],
         )
 
         # If the card got cleared, we need to replace the current discarded
         # card and update the discard pile. This is a little wasteful but we'll
         # wait to profile before we inline it since it's rare.
         if players[0].hand[finger_index].is_cleared:
-            discard_pile = with_discard(discard_pile, discarded_card_index)
-            discard_pile = with_discard(discard_pile, card_index)
-            discard_pile = with_discard(discard_pile, card_index)
+            discard_pile = _with_discard(discard_pile, discarded_card_index)
+            discard_pile = _with_discard(discard_pile, card_index)
+            discard_pile = _with_discard(discard_pile, card_index)
             discarded_card_index = card_index
+
+        # Shuffle the discards into the draw pile if there are no more draws.
+        # Always do this at the end of states, if possible, so we don't have
+        # to juggle reshuffles before draws.
+        draw_pile, discard_pile = _with_shuffle(draw_pile, discard_pile)
 
         # Check if the current player won. If so, stop the game. Otherwise,
         # rotate players so the next is in the first slot.
@@ -555,13 +736,27 @@ class Game(NamedTuple):
             state = State.DRAW_OR_REPLACE_WITH_DISCARD
 
         return Game(
-            turn=self.turn + 1,
+            turn=turn + 1,
             state=state,
-            drawn_card_index=self.drawn_card_index,
-            draw_pile=self.draw_pile,
+            drawn_card_index=drawn_card_index,
+            draw_pile=draw_pile,
             discarded_card_index=discarded_card_index,
             discard_pile=discard_pile,
             players=players,
+        )
+
+    def with_random_card_replaced_with_discard(
+        self,
+        finger_index: int,
+        rng: random.Random = random,
+    ) -> Game:
+        """Randomly pick if the replaced card is hidden."""
+
+        return self.with_card_replaced_with_discard(
+            finger_index,
+            _pick_random_index(self.draw_pile, rng=rng)
+            if self.players[0].hand[finger_index].is_hidden
+            else None,
         )
 
     def with_forfeit(self) -> Game:

--- a/src/skyjo2/__init__.py
+++ b/src/skyjo2/__init__.py
@@ -179,7 +179,7 @@ class Player(NamedTuple):
 # MARK: Game
 
 
-def _pick_random_index(pile: Sequence[int], rng: random.Random = random) -> int:
+def _pick_random_index(pile: Sequence[int], rng: random.Random) -> int:
     needle = rng.randint(0, sum(pile) - 1)
     for index, haystack in enumerate(pile):
         if needle < haystack:
@@ -391,7 +391,7 @@ class Game(NamedTuple):
             players=players,
         )
 
-    def with_random_first_cards_dealt(self, rng: random.Random = random) -> Game:
+    def with_random_first_cards_dealt(self, rng: random.Random) -> Game:
         """Deal players and set an initial discard."""
 
         turn = self.turn
@@ -495,7 +495,7 @@ class Game(NamedTuple):
     def with_random_second_card_revealed(
         self,
         finger_index: int,
-        rng: random.Random = random,
+        rng: random.Random,
     ) -> Game:
         """Pick a random card from the draw pile to reveal."""
 
@@ -540,7 +540,7 @@ class Game(NamedTuple):
             players=players,
         )
 
-    def with_random_drawn_card(self, rng: random.Random = random) -> Game:
+    def with_random_drawn_card(self, rng: random.Random) -> Game:
         """Draw a random card from the pile but do nothing with it."""
 
         drawn_card_index = _pick_random_index(self.draw_pile, rng=rng)
@@ -621,7 +621,7 @@ class Game(NamedTuple):
     def with_draw_discarded_and_random_card_revealed(
         self,
         finger_index: int,
-        rng: random.Random = random,
+        rng: random.Random,
     ) -> Game:
         """Pick a random card from the draw pile to reveal."""
 
@@ -712,7 +712,7 @@ class Game(NamedTuple):
     def with_random_card_replaced_with_draw(
         self,
         finger_index: int,
-        rng: random.Random = random,
+        rng: random.Random,
     ) -> Game:
         """Randomly pick if the replaced card is hidden."""
 
@@ -799,7 +799,7 @@ class Game(NamedTuple):
     def with_random_card_replaced_with_discard(
         self,
         finger_index: int,
-        rng: random.Random = random,
+        rng: random.Random,
     ) -> Game:
         """Randomly pick if the replaced card is hidden."""
 
@@ -865,7 +865,7 @@ class Game(NamedTuple):
             players=players,
         )
 
-    def with_random_hidden_cards_revealed(self, rng: random.Random = random) -> Game:
+    def with_random_hidden_cards_revealed(self, rng: random.Random) -> Game:
         """Draw hidden cards randomly."""
 
         turn = self.turn

--- a/src/skyjo2/__init__.py
+++ b/src/skyjo2/__init__.py
@@ -302,15 +302,15 @@ class Game(NamedTuple):
         )
 
     def with_deal(self, card_indices: Iterable[int]) -> Game:
-        (
-            turn,
-            state,
-            drawn_card_index,
-            draw_pile,
-            discarded_card_index,
-            discard_pile,
-            players,
-        ) = self
+        """Deal a set series of cards to the discard slot and players."""
+
+        turn = self.turn
+        state = self.state
+        drawn_card_index = self.drawn_card_index
+        draw_pile = self.draw_pile
+        discarded_card_index = self.discarded_card_index
+        discard_pile = self.discard_pile
+        players = self.players
         del self
 
         assert turn == 0
@@ -348,15 +348,13 @@ class Game(NamedTuple):
     def with_random_deal(self, rng: random.Random = random) -> Game:
         """Deal players and set an initial discard."""
 
-        (
-            turn,
-            state,
-            drawn_card_index,
-            draw_pile,
-            discarded_card_index,
-            discard_pile,
-            players,
-        ) = self
+        turn = self.turn
+        state = self.state
+        drawn_card_index = self.drawn_card_index
+        draw_pile = self.draw_pile
+        discarded_card_index = self.discarded_card_index
+        discard_pile = self.discard_pile
+        players = self.players
         del self
 
         assert turn == 0
@@ -398,15 +396,13 @@ class Game(NamedTuple):
     ) -> Game:
         """Reveal a second card during initial board setup."""
 
-        (
-            turn,
-            state,
-            drawn_card_index,
-            draw_pile,
-            discarded_card_index,
-            discard_pile,
-            players,
-        ) = self
+        turn = self.turn
+        state = self.state
+        drawn_card_index = self.drawn_card_index
+        draw_pile = self.draw_pile
+        discarded_card_index = self.discarded_card_index
+        discard_pile = self.discard_pile
+        players = self.players
         del self
 
         assert state == State.REVEAL_SECOND_CARD
@@ -429,10 +425,13 @@ class Game(NamedTuple):
         turn += 1
         if turn == len(players):
             state = State.DRAW_OR_REPLACE_WITH_DISCARD
-            turn += min(
+            lowest_hand_player_index = min(
                 range(len(players)),
                 key=lambda i: players[i].hand_score_revealed,
             )
+            for _ in range(lowest_hand_player_index):
+                turn += 1
+                players = (*players[1:], players[0])
 
         return Game(
             turn=turn,
@@ -459,19 +458,17 @@ class Game(NamedTuple):
     def with_drawn_card(self, drawn_card_index: int) -> Game:
         """Draw a specific card from the pile but do nothing with it."""
 
-        (
-            turn,
-            state,
-            drawn_card_index,
-            draw_pile,
-            discarded_card_index,
-            discard_pile,
-            players,
-        ) = self
+        turn = self.turn
+        state = self.state
+        old_drawn_card_index = self.drawn_card_index
+        draw_pile = self.draw_pile
+        discarded_card_index = self.discarded_card_index
+        discard_pile = self.discard_pile
+        players = self.players
         del self
 
         assert state == State.DRAW_OR_REPLACE_WITH_DISCARD
-        assert drawn_card_index is None
+        assert old_drawn_card_index is None
         assert sum(draw_pile) > 0
 
         # Remove the drawn card from the draw pile.
@@ -505,21 +502,29 @@ class Game(NamedTuple):
     ) -> Game:
         """Discard the drawn card and reveal a card in the current hand."""
 
-        (
-            turn,
-            state,
-            drawn_card_index,
-            draw_pile,
-            discarded_card_index,
-            discard_pile,
-            players,
-        ) = self
+        turn = self.turn
+        state = self.state
+        drawn_card_index = self.drawn_card_index
+        draw_pile = self.draw_pile
+        discarded_card_index = self.discarded_card_index
+        discard_pile = self.discard_pile
+        players = self.players
         del self
 
         assert state == State.DISCARD_DRAW_AND_REVEAL_OR_REPLACE_WITH_DRAW
         assert drawn_card_index is not None
         assert discarded_card_index is not None
         assert players[0].hand[finger_index].is_hidden
+
+        # Formally draw the revealed card.
+        draw_pile = _with_draw(draw_pile, revealed_card_index)
+
+        # Reveal the requested card.
+        finger_card_index = revealed_card_index
+        players = (
+            players[0].with_card(finger_index, finger_card_index),
+            *players[1:],
+        )
 
         # Put the current discarded card into the pile.
         discard_pile = _with_discard(discard_pile, discarded_card_index)
@@ -528,24 +533,14 @@ class Game(NamedTuple):
         discarded_card_index = drawn_card_index
         drawn_card_index = None
 
-        # Formally draw the revealed card.
-        draw_pile = _with_draw(draw_pile, revealed_card_index)
-
-        # Reveal the requested card.
-        card_index = players[0].hand[finger_index].card_index
-        players = (
-            players[0].with_card(finger_index, revealed_card_index),
-            *players[1:],
-        )
-
         # If the card got cleared, we need to replace the current discarded
         # card and update the discard pile. This is a little wasteful but we'll
         # wait to profile before we inline it since it's rare.
         if players[0].hand[finger_index].is_cleared:
             discard_pile = _with_discard(discard_pile, discarded_card_index)
-            discard_pile = _with_discard(discard_pile, card_index)
-            discard_pile = _with_discard(discard_pile, card_index)
-            discarded_card_index = card_index
+            discard_pile = _with_discard(discard_pile, finger_card_index)
+            discard_pile = _with_discard(discard_pile, finger_card_index)
+            discarded_card_index = finger_card_index
 
         # Shuffle the discards into the draw pile if there are no more draws.
         # Always do this at the end of states, if possible, so we don't have
@@ -589,51 +584,52 @@ class Game(NamedTuple):
     ) -> Game:
         """Replace a card in the current hand with the drawn card."""
 
-        (
-            turn,
-            state,
-            drawn_card_index,
-            draw_pile,
-            discarded_card_index,
-            discard_pile,
-            players,
-        ) = self
+        turn = self.turn
+        state = self.state
+        drawn_card_index = self.drawn_card_index
+        draw_pile = self.draw_pile
+        discarded_card_index = self.discarded_card_index
+        discard_pile = self.discard_pile
+        players = self.players
         del self
 
         assert state == State.DISCARD_DRAW_AND_REVEAL_OR_REPLACE_WITH_DRAW
         assert drawn_card_index is not None
 
-        # Put the current discarded card into the pile.
-        discard_pile = _with_discard(discard_pile, discarded_card_index)
-
-        # Move the replaced card to be the new discarded card. If the card was
-        # hidden, it needs to be formally drawn.
+        # Get the card being replaced. If it's hidden, we'll need to formally
+        # draw the preordained revealed card.
         finger = players[0].hand[finger_index]
-        discarded_card_index = finger.card_index
-        if discarded_card_index is None:
+        old_finger_card_index = finger.card_index
+        if old_finger_card_index is None:
             assert finger.is_hidden
             assert revealed_card_index is not None
             draw_pile = _with_draw(draw_pile, revealed_card_index)
-            discarded_card_index = revealed_card_index
+            old_finger_card_index = revealed_card_index
         else:
             assert revealed_card_index is None
 
-        # Replace the card in the player's hand.
-        card_index = drawn_card_index
+        # Replace the card in the player's hand with the drawn card.
+        finger_card_index = drawn_card_index
         drawn_card_index = None
         players = (
-            players[0].with_card(finger_index, card_index),
+            players[0].with_card(finger_index, finger_card_index),
             *players[1:],
         )
+
+        # Put the current discarded card into the pile.
+        discard_pile = _with_discard(discard_pile, discarded_card_index)
+
+        # Move the card that was previously in hand to the discard.
+        discarded_card_index = old_finger_card_index
 
         # If the card got cleared, we need to replace the current discarded
         # card and update the discard pile. This is a little wasteful but we'll
         # wait to profile before we inline it since it's rare.
         if players[0].hand[finger_index].is_cleared:
             discard_pile = _with_discard(discard_pile, discarded_card_index)
-            discard_pile = _with_discard(discard_pile, card_index)
-            discard_pile = _with_discard(discard_pile, card_index)
-            discarded_card_index = card_index
+            discard_pile = _with_discard(discard_pile, finger_card_index)
+            discard_pile = _with_discard(discard_pile, finger_card_index)
+            discarded_card_index = finger_card_index
 
         # Shuffle the discards into the draw pile if there are no more draws.
         # Always do this at the end of states, if possible, so we don't have
@@ -679,37 +675,35 @@ class Game(NamedTuple):
     ) -> Game:
         """Replace a card in the current hand with the drawn card."""
 
-        (
-            turn,
-            state,
-            drawn_card_index,
-            draw_pile,
-            discarded_card_index,
-            discard_pile,
-            players,
-        ) = self
+        turn = self.turn
+        state = self.state
+        drawn_card_index = self.drawn_card_index
+        draw_pile = self.draw_pile
+        discarded_card_index = self.discarded_card_index
+        discard_pile = self.discard_pile
+        players = self.players
         del self
 
         assert state == State.DRAW_OR_REPLACE_WITH_DISCARD
         assert drawn_card_index is None
 
-        # Put the current discarded card into the pile.
         # Move the replaced card to be the new discarded card. If the card was
         # hidden, it needs to be formally drawn.
         finger = players[0].hand[finger_index]
-        discarded_card_index = finger.card_index
-        if discarded_card_index is None:
+        old_finger_card_index = finger.card_index
+        if old_finger_card_index is None:
             assert finger.is_hidden
             assert revealed_card_index is not None
             draw_pile = _with_draw(draw_pile, revealed_card_index)
-            discarded_card_index = revealed_card_index
+            old_finger_card_index = revealed_card_index
         else:
             assert revealed_card_index is None
 
-        # Replace the card in the player's hand.
-        card_index = discarded_card_index
+        # Replace the card in the player's hand with the current discard.
+        finger_card_index = discarded_card_index
+        discarded_card_index = old_finger_card_index
         players = (
-            players[0].with_card(finger_index, card_index),
+            players[0].with_card(finger_index, finger_card_index),
             *players[1:],
         )
 
@@ -718,9 +712,9 @@ class Game(NamedTuple):
         # wait to profile before we inline it since it's rare.
         if players[0].hand[finger_index].is_cleared:
             discard_pile = _with_discard(discard_pile, discarded_card_index)
-            discard_pile = _with_discard(discard_pile, card_index)
-            discard_pile = _with_discard(discard_pile, card_index)
-            discarded_card_index = card_index
+            discard_pile = _with_discard(discard_pile, finger_card_index)
+            discard_pile = _with_discard(discard_pile, finger_card_index)
+            discarded_card_index = finger_card_index
 
         # Shuffle the discards into the draw pile if there are no more draws.
         # Always do this at the end of states, if possible, so we don't have

--- a/src/skyjo2/__init__.py
+++ b/src/skyjo2/__init__.py
@@ -29,6 +29,8 @@ CARD_COUNTS = tuple(DECK.values())
 HAND_ROWS = 3
 HAND_COLUMNS = 4
 
+# MARK: Finger
+
 
 class Finger(NamedTuple):
     """The state of an individual card on a player's board."""
@@ -47,16 +49,16 @@ class Finger(NamedTuple):
     def is_hidden(self) -> bool:
         return not self.is_revealed
 
-    def with_deal(self, card_index: int | None, is_revealed: bool = False) -> None:
-        return Finger(card_index, is_revealed=is_revealed)
-
-    def with_card(self, card_index: int) -> Finger:
-        return Finger(card_index, True)
+    def with_card(self, card_index: int | None) -> Finger:
+        return Finger(card_index, card_index is not None)
 
     def with_cleared(self) -> Finger:
         assert self.card_index is not None
         assert self.is_revealed
         return Finger(None, True)
+
+
+# MARK: Player
 
 
 class Player(NamedTuple):
@@ -89,6 +91,12 @@ class Player(NamedTuple):
         )
 
     @property
+    def hand_hidden_count(self) -> int:
+        """Get the number of cards revealed but not cleared in the hand."""
+
+        return sum(not finger.is_cleared and finger.is_hidden for finger in self.hand)
+
+    @property
     def hand_revealed_count(self) -> int:
         """Get the number of cards revealed but not cleared in the hand."""
 
@@ -106,7 +114,7 @@ class Player(NamedTuple):
 
         return all(finger.is_cleared or finger.is_revealed for finger in self.hand)
 
-    def with_deal(self, card_index: int) -> Player:
+    def with_first_card_dealt(self, card_index: int) -> Player:
         """Deal the top left card to the player."""
 
         # Always deal the top left card facing up. The rules do not specify
@@ -118,11 +126,7 @@ class Player(NamedTuple):
         # allow the player to choose the second card to reveal. Only two
         # positions are commutatively distinct: in the same column and not.
         hand = tuple(
-            (
-                finger.with_deal(card_index, is_revealed=True)
-                if i == 0
-                else finger.with_deal(None, is_revealed=False)
-            )
+            finger.with_card(card_index) if i == 0 else finger.with_card(None)
             for i, finger in enumerate(self.hand)
         )
 
@@ -153,6 +157,25 @@ class Player(NamedTuple):
             )
 
         return Player(score=self.score, hand=hand)
+
+    def with_hidden_cards_revealed(
+        self,
+        revealed_card_indices: Iterable[int],
+    ) -> Player:
+        """Replace remaining hidden cards."""
+
+        revealed_card_indices = iter(revealed_card_indices)
+        hand = tuple(
+            finger
+            if not finger.is_hidden
+            else finger.with_card(next(revealed_card_indices))
+            for finger in self.hand
+        )
+
+        return Player(score=self.score, hand=hand)
+
+
+# MARK: Game
 
 
 def _pick_random_index(pile: Sequence[int], rng: random.Random = random) -> int:
@@ -241,6 +264,18 @@ class Game(NamedTuple):
         return self.players[-offset:] + self.players[:-offset]
 
     @property
+    def player_hand_hidden_counts(self) -> tuple[int]:
+        return tuple(player.hand_hidden_count for player in self.players)
+
+    @property
+    def player_hand_revealed_counts(self) -> tuple[int]:
+        return tuple(player.hand_revealed_count for player in self.players)
+
+    @property
+    def player_hand_cleared_counts(self) -> tuple[int]:
+        return tuple(player.hand_cleared_count for player in self.players)
+
+    @property
     def final_scores(self) -> tuple[int, ...]:
         """Get player scores as if the current player ended the round."""
 
@@ -285,6 +320,8 @@ class Game(NamedTuple):
     def is_forfeit(self) -> bool:
         return self.is_finished and any(finger.is_hidden for finger in self.player.hand)
 
+    # MARK: Construct
+
     @staticmethod
     def new(*, players: int) -> Game:
         """Construct a new game."""
@@ -301,7 +338,9 @@ class Game(NamedTuple):
             players=(player,) * players,
         )
 
-    def with_deal(self, card_indices: Iterable[int]) -> Game:
+    # MARK: Deal
+
+    def with_first_cards_dealt(self, card_indices: Iterable[int]) -> Game:
         """Deal a set series of cards to the discard slot and players."""
 
         turn = self.turn
@@ -332,7 +371,8 @@ class Game(NamedTuple):
         # Exhaust the draw pile before we snapshot it as a `tuple` below.
         discarded_card_index = next(dealer)
         players = tuple(
-            player.with_deal(card_index) for player, card_index in zip(players, dealer)
+            player.with_first_card_dealt(card_index)
+            for player, card_index in zip(players, dealer)
         )
 
         return Game(
@@ -345,7 +385,7 @@ class Game(NamedTuple):
             players=players,
         )
 
-    def with_random_deal(self, rng: random.Random = random) -> Game:
+    def with_random_first_cards_dealt(self, rng: random.Random = random) -> Game:
         """Deal players and set an initial discard."""
 
         turn = self.turn
@@ -376,7 +416,8 @@ class Game(NamedTuple):
         # Exhaust the draw pile before we snapshot it as a `tuple` below.
         discarded_card_index = next(dealer)
         players = tuple(
-            player.with_deal(card_index) for player, card_index in zip(players, dealer)
+            player.with_first_card_dealt(card_index)
+            for player, card_index in zip(players, dealer)
         )
 
         return Game(
@@ -388,6 +429,8 @@ class Game(NamedTuple):
             discard_pile=discard_pile,
             players=players,
         )
+
+    # MARK: Second card
 
     def with_second_card_revealed(
         self,
@@ -455,6 +498,8 @@ class Game(NamedTuple):
             _pick_random_index(self.draw_pile, rng=rng),
         )
 
+    # MARK: Draw
+
     def with_drawn_card(self, drawn_card_index: int) -> Game:
         """Draw a specific card from the pile but do nothing with it."""
 
@@ -494,6 +539,8 @@ class Game(NamedTuple):
 
         drawn_card_index = _pick_random_index(self.draw_pile, rng=rng)
         return self.with_drawn_card(drawn_card_index)
+
+    # MARK: Discard draw and reveal
 
     def with_draw_discarded_and_card_revealed(
         self,
@@ -576,6 +623,8 @@ class Game(NamedTuple):
             finger_index,
             _pick_random_index(self.draw_pile, rng=rng),
         )
+
+    # MARK: Replace with draw
 
     def with_card_replaced_with_draw(
         self,
@@ -668,6 +717,8 @@ class Game(NamedTuple):
             else None,
         )
 
+    # MARK: Replace with discard
+
     def with_card_replaced_with_discard(
         self,
         finger_index: int,
@@ -753,6 +804,8 @@ class Game(NamedTuple):
             else None,
         )
 
+    # MARK: Forfeit
+
     def with_forfeit(self) -> Game:
         """Give up as the current player, forcing a loss."""
 
@@ -764,4 +817,84 @@ class Game(NamedTuple):
             discarded_card_index=self.discarded_card_index,
             discard_pile=self.discard_pile,
             players=self.players,
+        )
+
+    # MARK: Reveal remaining
+
+    def with_hidden_cards_revealed(self, revealed_card_indices: Iterable[int]) -> Game:
+        """Draw hidden cards in player hands at the end of the game."""
+
+        turn = self.turn
+        state = self.state
+        drawn_card_index = self.drawn_card_index
+        draw_pile = self.draw_pile
+        discarded_card_index = self.discarded_card_index
+        discard_pile = self.discard_pile
+        players = self.players
+        del self
+
+        assert state == State.NULL
+        assert drawn_card_index is None
+        assert players[0].hand_hidden_count == 0
+
+        mutable_draw_pile = list(draw_pile)
+        del draw_pile
+
+        def deal_revealed_card_index_from_draw_pile() -> Iterator[int]:
+            for revealed_card_index in revealed_card_indices:
+                assert mutable_draw_pile[revealed_card_index] > 0
+                mutable_draw_pile[revealed_card_index] -= 1
+                yield revealed_card_index
+
+        dealer = deal_revealed_card_index_from_draw_pile()
+
+        players = tuple(player.with_hidden_cards_revealed(dealer) for player in players)
+
+        return Game(
+            turn=turn,
+            state=state,
+            drawn_card_index=drawn_card_index,
+            draw_pile=tuple(mutable_draw_pile),
+            discarded_card_index=discarded_card_index,
+            discard_pile=discard_pile,
+            players=players,
+        )
+
+    def with_random_hidden_cards_revealed(self, rng: random.Random = random) -> Game:
+        """Draw hidden cards randomly."""
+
+        turn = self.turn
+        state = self.state
+        drawn_card_index = self.drawn_card_index
+        draw_pile = self.draw_pile
+        discarded_card_index = self.discarded_card_index
+        discard_pile = self.discard_pile
+        players = self.players
+        del self
+
+        assert state == State.NULL
+        assert drawn_card_index is None
+        assert players[0].hand_hidden_count == 0
+
+        mutable_draw_pile = list(draw_pile)
+        del draw_pile
+
+        def deal_revealed_card_index_from_draw_pile() -> Iterator[int]:
+            while True:
+                revealed_card_index = _pick_random_index(mutable_draw_pile, rng=rng)
+                mutable_draw_pile[revealed_card_index] -= 1
+                yield revealed_card_index
+
+        dealer = deal_revealed_card_index_from_draw_pile()
+
+        players = tuple(player.with_hidden_cards_revealed(dealer) for player in players)
+
+        return Game(
+            turn=turn,
+            state=state,
+            drawn_card_index=drawn_card_index,
+            draw_pile=tuple(mutable_draw_pile),
+            discarded_card_index=discarded_card_index,
+            discard_pile=discard_pile,
+            players=players,
         )

--- a/src/skyjo2/__init__.py
+++ b/src/skyjo2/__init__.py
@@ -47,16 +47,10 @@ class Finger(NamedTuple):
     def is_hidden(self) -> bool:
         return not self.is_revealed
 
-    def with_deal(self, card_index: int, is_revealed: bool = False) -> None:
+    def with_deal(self, card_index: int | None, is_revealed: bool = False) -> None:
         return Finger(card_index, is_revealed=is_revealed)
 
-    def with_revealed(self) -> Finger:
-        assert self.card_index is not None
-        assert not self.is_revealed
-        return Finger(self.card_index, True)
-
-    def with_replaced(self, card_index: int) -> Finger:
-        assert self.card_index is not None
+    def with_card(self, card_index: int) -> Finger:
         return Finger(card_index, True)
 
     def with_cleared(self) -> Finger:
@@ -112,8 +106,8 @@ class Player(NamedTuple):
 
         return all(finger.is_cleared or finger.is_revealed for finger in self.hand)
 
-    def with_deal(self, card_indices: Iterable[int]) -> Player:
-        """Deal a hand to the player."""
+    def with_deal(self, card_index: int) -> Player:
+        """Deal the top left card to the player."""
 
         # Always deal the top left card facing up. The rules do not specify
         # whether players should, at the start of the game, reveal their
@@ -124,52 +118,28 @@ class Player(NamedTuple):
         # allow the player to choose the second card to reveal. Only two
         # positions are commutatively distinct: in the same column and not.
         hand = tuple(
-            finger.with_deal(card_index, is_revealed=i == 0)
-            for i, (finger, card_index) in enumerate(zip(self.hand, card_indices))
+            (
+                finger.with_deal(card_index, is_revealed=True)
+                if i == 0
+                else finger.with_deal(None, is_revealed=False)
+            )
+            for i, finger in enumerate(self.hand)
         )
 
         return Player(score=self.score, hand=hand)
 
-    def with_revealed_card(self, finger_index: int) -> Player:
+    def with_card(self, finger_index: int, card_index: int) -> Player:
         """Reveal a card present on the board."""
 
         assert not self.hand[finger_index].is_cleared
-        assert self.hand[finger_index].is_hidden
 
         hand = (
             *self.hand[:finger_index],
-            self.hand[finger_index].with_revealed(),
+            self.hand[finger_index].with_card(card_index),
             *self.hand[finger_index + 1 :],
         )
 
         # Clear if the revealed card matches its column.
-        card_index = self.hand[finger_index].card_index
-        column_start = (finger_index // HAND_ROWS) * HAND_ROWS
-        column_stop = column_start + HAND_ROWS
-        if all(
-            finger.is_revealed and finger.card_index == card_index
-            for finger in hand[column_start:column_stop]
-        ):
-            hand = (
-                *hand[:column_start],
-                *map(Finger.with_cleared, hand[column_start:column_stop]),
-                *hand[column_stop:],
-            )
-
-        return Player(score=self.score, hand=hand)
-
-    def with_replaced_card(self, finger_index: int, card_index: int) -> Player:
-        """Replace a card present on the board."""
-
-        assert not self.hand[finger_index].is_cleared
-
-        hand = (
-            *self.hand[:finger_index],
-            self.hand[finger_index].with_replaced(card_index),
-            *self.hand[finger_index + 1 :],
-        )
-
-        # Clear if the replaced card matches its column.
         column_start = (finger_index // HAND_ROWS) * HAND_ROWS
         column_stop = column_start + HAND_ROWS
         if all(
@@ -330,7 +300,10 @@ class Game(NamedTuple):
 
         # Exhaust the draw pile before we snapshot it as a `tuple` below.
         discarded_card_index = next(dealer)
-        players = tuple(player.with_deal(dealer) for player in self.players)
+        players = tuple(
+            player.with_deal(card_index)
+            for player, card_index in zip(self.players, dealer)
+        )
 
         return Game(
             turn=self.turn,
@@ -362,7 +335,10 @@ class Game(NamedTuple):
 
         # Exhaust the draw pile before we snapshot it as a `tuple` below.
         discarded_card_index = next(dealer)
-        players = tuple(player.with_deal(dealer) for player in self.players)
+        players = tuple(
+            player.with_deal(card_index)
+            for player, card_index in zip(self.players, dealer)
+        )
 
         return Game(
             turn=self.turn,
@@ -374,14 +350,18 @@ class Game(NamedTuple):
             players=players,
         )
 
-    def with_second_card_revealed(self, finger_index: int) -> Game:
+    def with_second_card_revealed(self, finger_index: int, card_index: int) -> Game:
         """Reveal a second card during initial board setup."""
 
         assert self.state == State.REVEAL_SECOND_CARD
 
+        # Formally draw the card we're revealing.
+        draw_pile = with_draw(self.draw_pile, card_index)
+
         # Reveal the requested card.
+        assert self.players[0].hand[finger_index].is_hidden
         players = (
-            self.players[0].with_revealed_card(finger_index),
+            self.players[0].with_card(finger_index, card_index),
             *self.players[1:],
         )
 
@@ -403,7 +383,7 @@ class Game(NamedTuple):
             turn=turn,
             state=state,
             drawn_card_index=self.drawn_card_index,
-            draw_pile=self.draw_pile,
+            draw_pile=draw_pile,
             discarded_card_index=self.discarded_card_index,
             discard_pile=self.discard_pile,
             players=players,

--- a/src/skyjo2/__init__.py
+++ b/src/skyjo2/__init__.py
@@ -74,6 +74,7 @@ class Player(NamedTuple):
     def hand_score(self) -> int:
         """The total score of the hand, ignoring revealed."""
 
+        assert self.is_hand_revealed
         return sum(
             CARD_VALUES[finger.card_index]
             for finger in self.hand

--- a/src/skyjo2/play.py
+++ b/src/skyjo2/play.py
@@ -95,7 +95,7 @@ def play(
     game = Game.new(players=len(players))
     yield game
 
-    game = game.with_random_deal(rng=rng)
+    game = game.with_random_first_cards_dealt(rng=rng)
     yield game
 
     while game.state != State.NULL:

--- a/src/skyjo2/play.py
+++ b/src/skyjo2/play.py
@@ -109,27 +109,41 @@ def play(
                 Game(state=State.REVEAL_SECOND_CARD),
                 RevealSecondCard(finger_index),
             ):
-                game = game.with_second_card_revealed(finger_index)
+                game = game.with_random_second_card_revealed(
+                    finger_index,
+                    rng=rng,
+                )
             case (
                 Game(state=State.DRAW_OR_REPLACE_WITH_DISCARD),
                 DrawCard(),
             ):
-                game = game.with_random_drawn_card(rng=rng)
+                game = game.with_random_drawn_card(
+                    rng=rng,
+                )
             case (
                 Game(state=State.DISCARD_DRAW_AND_REVEAL_OR_REPLACE_WITH_DRAW),
                 DiscardDrawAndRevealCard(finger_index),
             ):
-                game = game.with_draw_discarded_and_card_revealed(finger_index)
+                game = game.with_draw_discarded_and_random_card_revealed(
+                    finger_index,
+                    rng=rng,
+                )
             case (
                 Game(state=State.DISCARD_DRAW_AND_REVEAL_OR_REPLACE_WITH_DRAW),
                 ReplaceCardWithDraw(finger_index),
             ):
-                game = game.with_card_replaced_with_draw(finger_index)
+                game = game.with_random_card_replaced_with_draw(
+                    finger_index,
+                    rng=rng,
+                )
             case (
                 Game(state=State.DRAW_OR_REPLACE_WITH_DISCARD),
                 ReplaceCardWithDiscard(finger_index),
             ):
-                game = game.with_card_replaced_with_discard(finger_index)
+                game = game.with_random_card_replaced_with_discard(
+                    finger_index,
+                    rng=rng,
+                )
             case _, _:
                 raise Rule(f"Invalid action {action} for game {game}")
 

--- a/src/skyjo2/play.py
+++ b/src/skyjo2/play.py
@@ -83,7 +83,7 @@ def play(
     players: Sequence[Player],
     rng: random.Random = random,
     *,
-    no_progress_turn_max: int = 20,
+    no_progress_turn_max: int | None = None,
 ) -> Iterator[Game]:
     """Orchestrate a game between the provided players."""
 
@@ -157,11 +157,13 @@ def play(
         # Check if the current player has exceeded the limit for turns without
         # making progress, and if so, forfeit. Doing so sets the game's state
         # to `State.NULL`, meaning we don't have to break.
-        turn_per_player = turn // len(players)
-        if last_progress_turns[player_index] - turn_per_player > no_progress_turn_max:
-            game = game.with_forfeit()
-            yield game
-            break
+        if no_progress_turn_max is not None:
+            turn_per_player = turn // len(players)
+            no_progress_turn_count = last_progress_turns[player_index] - turn_per_player
+            if no_progress_turn_count > no_progress_turn_max:
+                game = game.with_forfeit()
+                yield game
+                break
 
     # Reveal all hidden cards.
     game = game.with_random_hidden_cards_revealed(rng=rng)
@@ -171,7 +173,12 @@ def play(
 class RandomPlayer(Player):
     """Proof of concept player that picks a random action."""
 
+    rng: random.Random
+
+    def __init__(self, rng: random.Random = random) -> None:
+        self.rng = rng
+
     def play(self, game: Game) -> Action:
         actions = tuple(explore(game))
         assert len(actions) > 0
-        return random.choice(actions)
+        return self.rng.choice(actions)

--- a/src/skyjo2/play.py
+++ b/src/skyjo2/play.py
@@ -50,7 +50,7 @@ class Player(Protocol):
 def explore(game: Game) -> Iterator[Action]:
     """Yield all actions that may be played for a given game."""
 
-    if game.state == State.NULL:
+    if game.state == State.DEAL_FIRST_CARD:
         return
 
     elif game.state == State.REVEAL_SECOND_CARD:
@@ -98,7 +98,7 @@ def play(
     game = game.with_random_first_cards_dealt(rng=rng)
     yield game
 
-    while game.state != State.NULL:
+    while not game.is_ended_or_forfeited:
         turn = game.turn
         player_index = turn % len(players)
         player_hand_revealed_count = game.player.hand_revealed_count
@@ -161,6 +161,11 @@ def play(
         if last_progress_turns[player_index] - turn_per_player > no_progress_turn_max:
             game = game.with_forfeit()
             yield game
+            break
+
+    # Reveal all hidden cards.
+    game = game.with_random_hidden_cards_revealed(rng=rng)
+    yield game
 
 
 class RandomPlayer(Player):

--- a/tests/test_skyjo2.py
+++ b/tests/test_skyjo2.py
@@ -55,7 +55,7 @@ class TestGame:
 
     def test_with_deal(self) -> None:
         game = sj.Game.new(players=2)
-        game = game.with_deal((0, 1, 2))
+        game = game.with_first_cards_dealt((0, 1, 2))
         assert game == sj.Game(
             turn=0,
             state=sj.State.REVEAL_SECOND_CARD,
@@ -119,7 +119,7 @@ class TestGame:
 
     def test_with_random_deal(self, rng: random.Random) -> None:
         game = sj.Game.new(players=2)
-        game = game.with_random_deal(rng=rng)
+        game = game.with_random_first_cards_dealt(rng=rng)
         assert game == sj.Game(
             turn=0,
             state=sj.State.REVEAL_SECOND_CARD,
@@ -167,7 +167,7 @@ class TestGame:
 
     def test_with_second_card_revealed(self, rng: random.Random) -> None:
         game = sj.Game.new(players=2)
-        game = game.with_random_deal(rng=rng)
+        game = game.with_random_first_cards_dealt(rng=rng)
         game = game.with_random_second_card_revealed(1, rng=rng)
         assert game == sj.Game(
             turn=1,
@@ -261,7 +261,7 @@ class TestGame:
 
     def test_with_random_drawn_card(self, rng: random.Random) -> None:
         game = sj.Game.new(players=2)
-        game = game.with_random_deal(rng=rng)
+        game = game.with_random_first_cards_dealt(rng=rng)
         game = game.with_random_second_card_revealed(1, rng=rng)
         game = game.with_random_second_card_revealed(sj.HAND_ROWS, rng=rng)
         game = game.with_random_drawn_card(rng=rng)
@@ -312,7 +312,7 @@ class TestGame:
 
     def test_with_draw_discarded_and_card_revealed(self, rng: random.Random) -> None:
         game = sj.Game.new(players=2)
-        game = game.with_random_deal(rng=rng)
+        game = game.with_random_first_cards_dealt(rng=rng)
         game = game.with_random_second_card_revealed(1, rng=rng)
         game = game.with_random_second_card_revealed(sj.HAND_ROWS, rng=rng)
         game = game.with_random_drawn_card(rng=rng)
@@ -364,7 +364,7 @@ class TestGame:
 
     def test_with_draw_discarded_and_card_revealed_clear(self) -> None:
         game = sj.Game.new(players=2)
-        game = game.with_deal((0, 1, 2))
+        game = game.with_first_cards_dealt((0, 1, 2))
         game = game.with_second_card_revealed(1, 1)  # player 1
         game = game.with_second_card_revealed(1, 2)  # player 2
         game = game.with_drawn_card(0)  # player 1
@@ -555,7 +555,7 @@ class TestGame:
 
     def test_with_card_replaced_with_draw(self, rng: random.Random) -> None:
         game = sj.Game.new(players=2)
-        game = game.with_random_deal(rng=rng)
+        game = game.with_random_first_cards_dealt(rng=rng)
         game = game.with_random_second_card_revealed(1, rng=rng)
         game = game.with_random_second_card_revealed(sj.HAND_ROWS, rng=rng)
         game = game.with_random_drawn_card(rng=rng)
@@ -607,7 +607,7 @@ class TestGame:
 
     def test_with_card_replaced_with_draw_clear(self) -> None:
         game = sj.Game.new(players=2)
-        game = game.with_deal((0, 1, 2))
+        game = game.with_first_cards_dealt((0, 1, 2))
         game = game.with_second_card_revealed(1, 1)  # player 1
         game = game.with_second_card_revealed(1, 2)  # player 2
         game = game.with_drawn_card(1)  # player 1
@@ -798,7 +798,7 @@ class TestGame:
 
     def test_with_card_replaced_with_discard(self, rng: random.Random) -> None:
         game = sj.Game.new(players=2)
-        game = game.with_random_deal(rng=rng)
+        game = game.with_random_first_cards_dealt(rng=rng)
         game = game.with_random_second_card_revealed(1, rng=rng)
         game = game.with_random_second_card_revealed(sj.HAND_ROWS, rng=rng)
         game = game.with_random_card_replaced_with_discard(1, rng=rng)
@@ -849,7 +849,7 @@ class TestGame:
 
     def test_with_card_replaced_with_discard_clear(self, rng: random.Random) -> None:
         game = sj.Game.new(players=2)
-        game = game.with_deal((1, 1, 2))
+        game = game.with_first_cards_dealt((1, 1, 2))
         game = game.with_second_card_revealed(1, 1)  # player 1
         game = game.with_second_card_revealed(1, 2)  # player 2
         game = game.with_card_replaced_with_discard(2, 0)  # player 1

--- a/tests/test_skyjo2.py
+++ b/tests/test_skyjo2.py
@@ -10,7 +10,7 @@ class TestGame:
         game = sj.Game.new(players=2)
         assert game == sj.Game(
             turn=0,
-            state=sj.State.NULL,
+            state=sj.State.DEAL_FIRST_CARD,
             drawn_card_index=None,
             draw_pile=(5, 10, 15, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10),
             discarded_card_index=None,
@@ -494,7 +494,7 @@ class TestGame:
         game = game.with_draw_discarded_and_card_revealed(11, 12)
         assert game == sj.Game(
             turn=101,
-            state=sj.State.NULL,
+            state=sj.State.ENDED,
             drawn_card_index=None,
             draw_pile=(
                 5 - 2,
@@ -737,7 +737,7 @@ class TestGame:
         game = game.with_card_replaced_with_draw(11, 12)
         assert game == sj.Game(
             turn=101,
-            state=sj.State.NULL,
+            state=sj.State.ENDED,
             drawn_card_index=None,
             draw_pile=(
                 5 - 2,
@@ -978,7 +978,7 @@ class TestGame:
         game = game.with_card_replaced_with_discard(11, 12)
         assert game == sj.Game(
             turn=101,
-            state=sj.State.NULL,
+            state=sj.State.ENDED,
             drawn_card_index=None,
             draw_pile=(
                 5 - 1,
@@ -1040,7 +1040,7 @@ class TestGame:
     def test_with_hidden_cards_revealed_tie(self) -> None:
         game = sj.Game(
             turn=100,
-            state=sj.State.NULL,
+            state=sj.State.ENDED,
             drawn_card_index=None,
             draw_pile=(
                 5 - 1,  # initial discard
@@ -1101,7 +1101,7 @@ class TestGame:
         game = game.with_hidden_cards_revealed((11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1))
         assert game == sj.Game(
             turn=100,
-            state=sj.State.NULL,
+            state=sj.State.ENDED,
             drawn_card_index=None,
             draw_pile=(
                 5 - 1,  # initial discard
@@ -1167,7 +1167,7 @@ class TestGame:
     def test_with_hidden_cards_revealed_lose(self) -> None:
         game = sj.Game(
             turn=100,
-            state=sj.State.NULL,
+            state=sj.State.ENDED,
             drawn_card_index=None,
             draw_pile=(
                 5 - 1,  # initial discard
@@ -1228,7 +1228,7 @@ class TestGame:
         game = game.with_hidden_cards_revealed((2,) * 11)
         assert game == sj.Game(
             turn=100,
-            state=sj.State.NULL,
+            state=sj.State.ENDED,
             drawn_card_index=None,
             draw_pile=(
                 5 - 1,  # initial discard
@@ -1294,7 +1294,7 @@ class TestGame:
     def test_with_hidden_cards_revealed_win(self) -> None:
         game = sj.Game(
             turn=100,
-            state=sj.State.NULL,
+            state=sj.State.ENDED,
             drawn_card_index=None,
             draw_pile=(
                 5 - 1,  # initial discard
@@ -1355,7 +1355,7 @@ class TestGame:
         game = game.with_hidden_cards_revealed((14,) * 5 + (13,) * 6)
         assert game == sj.Game(
             turn=100,
-            state=sj.State.NULL,
+            state=sj.State.ENDED,
             drawn_card_index=None,
             draw_pile=(
                 5 - 1,  # initial discard
@@ -1421,7 +1421,7 @@ class TestGame:
     def test_with_random_hidden_cards_revealed(self, rng: random.Random) -> None:
         game = sj.Game(
             turn=100,
-            state=sj.State.NULL,
+            state=sj.State.ENDED,
             drawn_card_index=None,
             draw_pile=(
                 5 - 1,  # initial discard
@@ -1482,7 +1482,7 @@ class TestGame:
         game = game.with_random_hidden_cards_revealed(rng=rng)
         assert game == sj.Game(
             turn=100,
-            state=sj.State.NULL,
+            state=sj.State.ENDED,
             drawn_card_index=None,
             draw_pile=(4, 8, 14, 9, 9, 8, 9, 8, 7, 9, 8, 8, 7, 10, 7),
             discarded_card_index=0,

--- a/tests/test_skyjo2.py
+++ b/tests/test_skyjo2.py
@@ -55,23 +55,19 @@ class TestGame:
 
     def test_with_deal(self) -> None:
         game = sj.Game.new(players=2)
-        game = game.with_deal(
-            (0,)  # discard
-            + ((1, 2, 3) + (1, 2, 3) + (1, 2, 3) + (1, 2, 3))  # player 1
-            + ((4, 5, 6) + (4, 5, 6) + (4, 5, 6) + (4, 5, 6)),  # player 2
-        )
+        game = game.with_deal((0, 1, 2))
         assert game == sj.Game(
             turn=0,
             state=sj.State.REVEAL_SECOND_CARD,
             drawn_card_index=None,
             draw_pile=(
                 5 - 1,
-                10 - 4,
-                15 - 4,
-                10 - 4,
-                10 - 4,
-                10 - 4,
-                10 - 4,
+                10 - 1,
+                15 - 1,
+                10,
+                10,
+                10,
+                10,
                 10,
                 10,
                 10,
@@ -88,34 +84,34 @@ class TestGame:
                     score=0,
                     hand=(
                         sj.Finger(card_index=1, is_revealed=True),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
-                        sj.Finger(card_index=1, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
-                        sj.Finger(card_index=1, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
-                        sj.Finger(card_index=1, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
                 sj.Player(
                     score=0,
                     hand=(
-                        sj.Finger(card_index=4, is_revealed=True),
-                        sj.Finger(card_index=5, is_revealed=False),
-                        sj.Finger(card_index=6, is_revealed=False),
-                        sj.Finger(card_index=4, is_revealed=False),
-                        sj.Finger(card_index=5, is_revealed=False),
-                        sj.Finger(card_index=6, is_revealed=False),
-                        sj.Finger(card_index=4, is_revealed=False),
-                        sj.Finger(card_index=5, is_revealed=False),
-                        sj.Finger(card_index=6, is_revealed=False),
-                        sj.Finger(card_index=4, is_revealed=False),
-                        sj.Finger(card_index=5, is_revealed=False),
-                        sj.Finger(card_index=6, is_revealed=False),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
             ),
@@ -128,7 +124,7 @@ class TestGame:
             turn=0,
             state=sj.State.REVEAL_SECOND_CARD,
             drawn_card_index=None,
-            draw_pile=(5, 8, 12, 8, 9, 9, 9, 7, 8, 7, 8, 10, 8, 9, 8),
+            draw_pile=(5, 9, 15, 10, 10, 10, 10, 10, 10, 9, 9, 10, 10, 10, 10),
             discarded_card_index=9,
             discard_pile=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
             players=(
@@ -136,34 +132,34 @@ class TestGame:
                     score=0,
                     hand=(
                         sj.Finger(card_index=10, is_revealed=True),
-                        sj.Finger(card_index=1, is_revealed=False),
-                        sj.Finger(card_index=6, is_revealed=False),
-                        sj.Finger(card_index=13, is_revealed=False),
-                        sj.Finger(card_index=12, is_revealed=False),
-                        sj.Finger(card_index=10, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=False),
-                        sj.Finger(card_index=12, is_revealed=False),
-                        sj.Finger(card_index=9, is_revealed=False),
-                        sj.Finger(card_index=5, is_revealed=False),
-                        sj.Finger(card_index=14, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
                 sj.Player(
                     score=0,
                     hand=(
-                        sj.Finger(card_index=7, is_revealed=True),
-                        sj.Finger(card_index=3, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=False),
-                        sj.Finger(card_index=4, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=9, is_revealed=False),
-                        sj.Finger(card_index=14, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
-                        sj.Finger(card_index=1, is_revealed=False),
+                        sj.Finger(card_index=1, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
             ),
@@ -172,92 +168,92 @@ class TestGame:
     def test_with_second_card_revealed(self, rng: random.Random) -> None:
         game = sj.Game.new(players=2)
         game = game.with_random_deal(rng=rng)
-        game = game.with_second_card_revealed(1)
+        game = game.with_random_second_card_revealed(1, rng=rng)
         assert game == sj.Game(
             turn=1,
             state=sj.State.REVEAL_SECOND_CARD,
             drawn_card_index=None,
-            draw_pile=(5, 8, 12, 8, 9, 9, 9, 7, 8, 7, 8, 10, 8, 9, 8),
+            draw_pile=(5, 9, 15, 10, 10, 10, 9, 10, 10, 9, 9, 10, 10, 10, 10),
             discarded_card_index=9,
             discard_pile=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
             players=(
                 sj.Player(
                     score=0,
                     hand=(
-                        sj.Finger(card_index=7, is_revealed=True),
-                        sj.Finger(card_index=3, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=False),
-                        sj.Finger(card_index=4, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=9, is_revealed=False),
-                        sj.Finger(card_index=14, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
-                        sj.Finger(card_index=1, is_revealed=False),
+                        sj.Finger(card_index=1, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
                 sj.Player(
                     score=0,
                     hand=(
                         sj.Finger(card_index=10, is_revealed=True),
-                        sj.Finger(card_index=1, is_revealed=True),
-                        sj.Finger(card_index=6, is_revealed=False),
-                        sj.Finger(card_index=13, is_revealed=False),
-                        sj.Finger(card_index=12, is_revealed=False),
-                        sj.Finger(card_index=10, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=False),
-                        sj.Finger(card_index=12, is_revealed=False),
-                        sj.Finger(card_index=9, is_revealed=False),
-                        sj.Finger(card_index=5, is_revealed=False),
-                        sj.Finger(card_index=14, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
+                        sj.Finger(card_index=6, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
             ),
         )
-        game = game.with_second_card_revealed(sj.HAND_ROWS)
+        game = game.with_random_second_card_revealed(sj.HAND_ROWS, rng=rng)
         assert game == sj.Game(
-            turn=2,
+            turn=3,  # skip one as lowest player gets to start
             state=sj.State.DRAW_OR_REPLACE_WITH_DISCARD,
             drawn_card_index=None,
-            draw_pile=(5, 8, 12, 8, 9, 9, 9, 7, 8, 7, 8, 10, 8, 9, 8),
+            draw_pile=(5, 9, 15, 10, 10, 10, 9, 10, 10, 9, 9, 10, 10, 9, 10),
             discarded_card_index=9,
             discard_pile=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
             players=(
                 sj.Player(
                     score=0,
                     hand=(
-                        sj.Finger(card_index=10, is_revealed=True),
                         sj.Finger(card_index=1, is_revealed=True),
-                        sj.Finger(card_index=6, is_revealed=False),
-                        sj.Finger(card_index=13, is_revealed=False),
-                        sj.Finger(card_index=12, is_revealed=False),
-                        sj.Finger(card_index=10, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=False),
-                        sj.Finger(card_index=12, is_revealed=False),
-                        sj.Finger(card_index=9, is_revealed=False),
-                        sj.Finger(card_index=5, is_revealed=False),
-                        sj.Finger(card_index=14, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=13, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
                 sj.Player(
                     score=0,
                     hand=(
-                        sj.Finger(card_index=7, is_revealed=True),
-                        sj.Finger(card_index=3, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=True),
-                        sj.Finger(card_index=4, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=9, is_revealed=False),
-                        sj.Finger(card_index=14, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
-                        sj.Finger(card_index=1, is_revealed=False),
+                        sj.Finger(card_index=10, is_revealed=True),
+                        sj.Finger(card_index=6, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
             ),
@@ -266,101 +262,101 @@ class TestGame:
     def test_with_random_drawn_card(self, rng: random.Random) -> None:
         game = sj.Game.new(players=2)
         game = game.with_random_deal(rng=rng)
-        game = game.with_second_card_revealed(1)
-        game = game.with_second_card_revealed(sj.HAND_ROWS)
+        game = game.with_random_second_card_revealed(1, rng=rng)
+        game = game.with_random_second_card_revealed(sj.HAND_ROWS, rng=rng)
         game = game.with_random_drawn_card(rng=rng)
         assert game == sj.Game(
-            turn=2,
+            turn=3,
             state=sj.State.DISCARD_DRAW_AND_REVEAL_OR_REPLACE_WITH_DRAW,
-            drawn_card_index=5,
-            draw_pile=(5, 8, 12, 8, 9, 8, 9, 7, 8, 7, 8, 10, 8, 9, 8),
+            drawn_card_index=12,
+            draw_pile=(5, 9, 15, 10, 10, 10, 9, 10, 10, 9, 9, 10, 9, 9, 10),
             discarded_card_index=9,
             discard_pile=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
             players=(
                 sj.Player(
                     score=0,
                     hand=(
-                        sj.Finger(card_index=10, is_revealed=True),
                         sj.Finger(card_index=1, is_revealed=True),
-                        sj.Finger(card_index=6, is_revealed=False),
-                        sj.Finger(card_index=13, is_revealed=False),
-                        sj.Finger(card_index=12, is_revealed=False),
-                        sj.Finger(card_index=10, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=False),
-                        sj.Finger(card_index=12, is_revealed=False),
-                        sj.Finger(card_index=9, is_revealed=False),
-                        sj.Finger(card_index=5, is_revealed=False),
-                        sj.Finger(card_index=14, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=13, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
                 sj.Player(
                     score=0,
                     hand=(
-                        sj.Finger(card_index=7, is_revealed=True),
-                        sj.Finger(card_index=3, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=True),
-                        sj.Finger(card_index=4, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=9, is_revealed=False),
-                        sj.Finger(card_index=14, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
-                        sj.Finger(card_index=1, is_revealed=False),
+                        sj.Finger(card_index=10, is_revealed=True),
+                        sj.Finger(card_index=6, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
             ),
         )
 
-    def with_draw_discarded_and_card_revealed(self, rng: random.Random) -> None:
+    def test_with_draw_discarded_and_card_revealed(self, rng: random.Random) -> None:
         game = sj.Game.new(players=2)
         game = game.with_random_deal(rng=rng)
-        game = game.with_second_card_revealed(1)
-        game = game.with_second_card_revealed(sj.HAND_ROWS)
+        game = game.with_random_second_card_revealed(1, rng=rng)
+        game = game.with_random_second_card_revealed(sj.HAND_ROWS, rng=rng)
         game = game.with_random_drawn_card(rng=rng)
-        game = game.with_draw_discarded_and_card_revealed(2)
+        game = game.with_draw_discarded_and_random_card_revealed(1, rng=rng)
         assert game == sj.Game(
-            turn=3,
-            state=sj.State.DISCARD_DRAW_AND_REVEAL_OR_REPLACE_WITH_DRAW,
+            turn=4,
+            state=sj.State.DRAW_OR_REPLACE_WITH_DISCARD,
             drawn_card_index=None,
-            draw_pile=(5, 9, 11, 8, 9, 8, 8, 7, 9, 7, 8, 10, 8, 9, 8),
-            discarded_card_index=6,
+            draw_pile=(5, 9, 15, 10, 10, 10, 9, 10, 10, 9, 8, 10, 9, 9, 10),
+            discarded_card_index=12,
             discard_pile=(0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0),
             players=(
                 sj.Player(
                     score=0,
                     hand=(
-                        sj.Finger(card_index=7, is_revealed=True),
-                        sj.Finger(card_index=3, is_revealed=True),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=False),
-                        sj.Finger(card_index=4, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=9, is_revealed=False),
-                        sj.Finger(card_index=14, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=5, is_revealed=False),
+                        sj.Finger(card_index=10, is_revealed=True),
+                        sj.Finger(card_index=6, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
                 sj.Player(
                     score=0,
                     hand=(
-                        sj.Finger(card_index=10, is_revealed=True),
                         sj.Finger(card_index=1, is_revealed=True),
-                        sj.Finger(card_index=6, is_revealed=True),
-                        sj.Finger(card_index=13, is_revealed=False),
-                        sj.Finger(card_index=12, is_revealed=False),
-                        sj.Finger(card_index=10, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=False),
-                        sj.Finger(card_index=12, is_revealed=False),
-                        sj.Finger(card_index=9, is_revealed=False),
-                        sj.Finger(card_index=5, is_revealed=False),
-                        sj.Finger(card_index=14, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
+                        sj.Finger(card_index=10, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=13, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
             ),
@@ -368,29 +364,25 @@ class TestGame:
 
     def test_with_draw_discarded_and_card_revealed_clear(self) -> None:
         game = sj.Game.new(players=2)
-        game = game.with_deal(
-            (0,)  # discard
-            + ((1, 1, 1) + (2, 2, 2) + (3, 3, 3) + (4, 4, 4))  # player 1
-            + ((5, 5, 5) + (6, 6, 6) + (7, 7, 7) + (8, 8, 8)),  # player 2
-        )
-        game = game.with_second_card_revealed(1)  # player 1
-        game = game.with_second_card_revealed(1)  # player 2
+        game = game.with_deal((0, 1, 2))
+        game = game.with_second_card_revealed(1, 1)  # player 1
+        game = game.with_second_card_revealed(1, 2)  # player 2
         game = game.with_drawn_card(0)  # player 1
-        game = game.with_draw_discarded_and_card_revealed(2)  # player 1
+        game = game.with_draw_discarded_and_card_revealed(2, 1)  # player 1
         assert game == sj.Game(
             turn=3,
             state=sj.State.DRAW_OR_REPLACE_WITH_DISCARD,
             drawn_card_index=None,
             draw_pile=(
                 5 - 2,  # initial discard, discarded draw
-                10 - 3,
-                15 - 3,
-                10 - 3,
-                10 - 3,
-                10 - 3,
-                10 - 3,
-                10 - 3,
-                10 - 3,
+                10 - 3,  # deal, reveal, reveal
+                15 - 2,  # deal, reveal
+                10,
+                10,
+                10,
+                10,
+                10,
+                10,
                 10,
                 10,
                 10,
@@ -404,18 +396,18 @@ class TestGame:
                 sj.Player(
                     score=0,
                     hand=(
-                        sj.Finger(card_index=5, is_revealed=True),
-                        sj.Finger(card_index=5, is_revealed=True),
-                        sj.Finger(card_index=5, is_revealed=False),
-                        sj.Finger(card_index=6, is_revealed=False),
-                        sj.Finger(card_index=6, is_revealed=False),
-                        sj.Finger(card_index=6, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
                 sj.Player(
@@ -424,28 +416,28 @@ class TestGame:
                         sj.Finger(card_index=None, is_revealed=True),
                         sj.Finger(card_index=None, is_revealed=True),
                         sj.Finger(card_index=None, is_revealed=True),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
-                        sj.Finger(card_index=4, is_revealed=False),
-                        sj.Finger(card_index=4, is_revealed=False),
-                        sj.Finger(card_index=4, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
             ),
         )
 
-    def test_with_draw_discarded_and_card_revealed_win(self) -> None:
+    def test_with_draw_discarded_and_card_revealed_end(self) -> None:
         game = sj.Game(
             turn=100,
             state=sj.State.DISCARD_DRAW_AND_REVEAL_OR_REPLACE_WITH_DRAW,
             drawn_card_index=0,
             draw_pile=(
                 5 - 2,  # initial discard, draw
-                10 - 2,
+                10 - 1,
                 15 - 2,
                 10 - 2,
                 10 - 2,
@@ -456,7 +448,7 @@ class TestGame:
                 10 - 2,
                 10 - 2,
                 10 - 2,
-                10 - 2,
+                10 - 1,
                 10,
                 10,
             ),
@@ -477,7 +469,7 @@ class TestGame:
                         sj.Finger(card_index=9, is_revealed=True),
                         sj.Finger(card_index=10, is_revealed=True),
                         sj.Finger(card_index=11, is_revealed=True),
-                        sj.Finger(card_index=12, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
                 sj.Player(
@@ -494,19 +486,19 @@ class TestGame:
                         sj.Finger(card_index=4, is_revealed=True),
                         sj.Finger(card_index=3, is_revealed=True),
                         sj.Finger(card_index=2, is_revealed=True),
-                        sj.Finger(card_index=1, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
             ),
         )
-        game = game.with_draw_discarded_and_card_revealed(11)
+        game = game.with_draw_discarded_and_card_revealed(11, 12)
         assert game == sj.Game(
             turn=101,
             state=sj.State.NULL,
             drawn_card_index=None,
             draw_pile=(
-                5 - 2,  #
-                10 - 2,
+                5 - 2,
+                10 - 1,
                 15 - 2,
                 10 - 2,
                 10 - 2,
@@ -555,60 +547,59 @@ class TestGame:
                         sj.Finger(card_index=4, is_revealed=True),
                         sj.Finger(card_index=3, is_revealed=True),
                         sj.Finger(card_index=2, is_revealed=True),
-                        sj.Finger(card_index=1, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
             ),
         )
-        assert game.winner_index == 0
 
     def test_with_card_replaced_with_draw(self, rng: random.Random) -> None:
         game = sj.Game.new(players=2)
         game = game.with_random_deal(rng=rng)
-        game = game.with_second_card_revealed(1)
-        game = game.with_second_card_revealed(sj.HAND_ROWS)
+        game = game.with_random_second_card_revealed(1, rng=rng)
+        game = game.with_random_second_card_revealed(sj.HAND_ROWS, rng=rng)
         game = game.with_random_drawn_card(rng=rng)
-        game = game.with_card_replaced_with_draw(3)
+        game = game.with_random_card_replaced_with_draw(1, rng=rng)
         assert game == sj.Game(
-            turn=3,
+            turn=4,
             state=sj.State.DRAW_OR_REPLACE_WITH_DISCARD,
             drawn_card_index=None,
-            draw_pile=(5, 8, 12, 8, 9, 8, 9, 7, 8, 7, 8, 10, 8, 9, 8),
-            discarded_card_index=13,
+            draw_pile=(5, 9, 15, 10, 10, 10, 9, 10, 10, 9, 8, 10, 9, 9, 10),
+            discarded_card_index=10,
             discard_pile=(0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0),
             players=(
                 sj.Player(
                     score=0,
                     hand=(
-                        sj.Finger(card_index=7, is_revealed=True),
-                        sj.Finger(card_index=3, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=True),
-                        sj.Finger(card_index=4, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=9, is_revealed=False),
-                        sj.Finger(card_index=14, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
-                        sj.Finger(card_index=1, is_revealed=False),
+                        sj.Finger(card_index=10, is_revealed=True),
+                        sj.Finger(card_index=6, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
                 sj.Player(
                     score=0,
                     hand=(
-                        sj.Finger(card_index=10, is_revealed=True),
                         sj.Finger(card_index=1, is_revealed=True),
-                        sj.Finger(card_index=6, is_revealed=False),
-                        sj.Finger(card_index=5, is_revealed=True),
-                        sj.Finger(card_index=12, is_revealed=False),
-                        sj.Finger(card_index=10, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=False),
-                        sj.Finger(card_index=12, is_revealed=False),
-                        sj.Finger(card_index=9, is_revealed=False),
-                        sj.Finger(card_index=5, is_revealed=False),
-                        sj.Finger(card_index=14, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
+                        sj.Finger(card_index=12, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=13, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
             ),
@@ -616,15 +607,11 @@ class TestGame:
 
     def test_with_card_replaced_with_draw_clear(self) -> None:
         game = sj.Game.new(players=2)
-        game = game.with_deal(
-            (0,)  # discard
-            + ((1, 1, 0) + (2, 2, 2) + (3, 3, 3) + (4, 4, 4))  # player 1
-            + ((5, 5, 5) + (6, 6, 6) + (7, 7, 7) + (8, 8, 8)),  # player 2
-        )
-        game = game.with_second_card_revealed(1)  # player 1
-        game = game.with_second_card_revealed(1)  # player 2
+        game = game.with_deal((0, 1, 2))
+        game = game.with_second_card_revealed(1, 1)  # player 1
+        game = game.with_second_card_revealed(1, 2)  # player 2
         game = game.with_drawn_card(1)  # player 1
-        game = game.with_card_replaced_with_draw(2)  # player 1
+        game = game.with_card_replaced_with_draw(2, 0)  # player 1
         assert game == sj.Game(
             turn=3,
             state=sj.State.DRAW_OR_REPLACE_WITH_DISCARD,
@@ -632,13 +619,13 @@ class TestGame:
             draw_pile=(
                 5 - 2,  # initial discard, replaced card
                 10 - 3,
-                15 - 3,
-                10 - 3,
-                10 - 3,
-                10 - 3,
-                10 - 3,
-                10 - 3,
-                10 - 3,
+                15 - 2,
+                10,
+                10,
+                10,
+                10,
+                10,
+                10,
                 10,
                 10,
                 10,
@@ -652,18 +639,18 @@ class TestGame:
                 sj.Player(
                     score=0,
                     hand=(
-                        sj.Finger(card_index=5, is_revealed=True),
-                        sj.Finger(card_index=5, is_revealed=True),
-                        sj.Finger(card_index=5, is_revealed=False),
-                        sj.Finger(card_index=6, is_revealed=False),
-                        sj.Finger(card_index=6, is_revealed=False),
-                        sj.Finger(card_index=6, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
                 sj.Player(
@@ -672,28 +659,28 @@ class TestGame:
                         sj.Finger(card_index=None, is_revealed=True),
                         sj.Finger(card_index=None, is_revealed=True),
                         sj.Finger(card_index=None, is_revealed=True),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
-                        sj.Finger(card_index=4, is_revealed=False),
-                        sj.Finger(card_index=4, is_revealed=False),
-                        sj.Finger(card_index=4, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
             ),
         )
 
-    def test_with_card_replaced_with_draw_win(self) -> None:
+    def test_with_card_replaced_with_draw_end(self) -> None:
         game = sj.Game(
             turn=100,
             state=sj.State.DISCARD_DRAW_AND_REVEAL_OR_REPLACE_WITH_DRAW,
             drawn_card_index=0,
             draw_pile=(
                 5 - 2,  # initial discard, draw
-                10 - 2,
+                10 - 1,
                 15 - 2,
                 10 - 2,
                 10 - 2,
@@ -704,7 +691,7 @@ class TestGame:
                 10 - 2,
                 10 - 2,
                 10 - 2,
-                10 - 2,
+                10 - 1,
                 10,
                 10,
             ),
@@ -725,7 +712,7 @@ class TestGame:
                         sj.Finger(card_index=9, is_revealed=True),
                         sj.Finger(card_index=10, is_revealed=True),
                         sj.Finger(card_index=11, is_revealed=True),
-                        sj.Finger(card_index=12, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
                 sj.Player(
@@ -742,19 +729,19 @@ class TestGame:
                         sj.Finger(card_index=4, is_revealed=True),
                         sj.Finger(card_index=3, is_revealed=True),
                         sj.Finger(card_index=2, is_revealed=True),
-                        sj.Finger(card_index=1, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
             ),
         )
-        game = game.with_card_replaced_with_draw(11)
+        game = game.with_card_replaced_with_draw(11, 12)
         assert game == sj.Game(
             turn=101,
             state=sj.State.NULL,
             drawn_card_index=None,
             draw_pile=(
-                5 - 2,  # initial discard, draw
-                10 - 2,
+                5 - 2,
+                10 - 1,
                 15 - 2,
                 10 - 2,
                 10 - 2,
@@ -803,59 +790,58 @@ class TestGame:
                         sj.Finger(card_index=4, is_revealed=True),
                         sj.Finger(card_index=3, is_revealed=True),
                         sj.Finger(card_index=2, is_revealed=True),
-                        sj.Finger(card_index=1, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
             ),
         )
-        assert game.winner_index == 0
 
     def test_with_card_replaced_with_discard(self, rng: random.Random) -> None:
         game = sj.Game.new(players=2)
         game = game.with_random_deal(rng=rng)
-        game = game.with_second_card_revealed(1)  # player 1
-        game = game.with_second_card_revealed(sj.HAND_ROWS)  # player 2
-        game = game.with_card_replaced_with_discard(2)  # player 1
+        game = game.with_random_second_card_revealed(1, rng=rng)
+        game = game.with_random_second_card_revealed(sj.HAND_ROWS, rng=rng)
+        game = game.with_random_card_replaced_with_discard(1, rng=rng)
         assert game == sj.Game(
-            turn=3,
+            turn=4,
             state=sj.State.DRAW_OR_REPLACE_WITH_DISCARD,
             drawn_card_index=None,
-            draw_pile=(5, 8, 12, 8, 9, 9, 9, 7, 8, 7, 8, 10, 8, 9, 8),
-            discarded_card_index=6,
+            draw_pile=(5, 9, 15, 10, 10, 10, 9, 10, 10, 9, 9, 10, 9, 9, 10),
+            discarded_card_index=12,
             discard_pile=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
             players=(
                 sj.Player(
                     score=0,
                     hand=(
-                        sj.Finger(card_index=7, is_revealed=True),
-                        sj.Finger(card_index=3, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=True),
-                        sj.Finger(card_index=4, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=9, is_revealed=False),
-                        sj.Finger(card_index=14, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
-                        sj.Finger(card_index=1, is_revealed=False),
+                        sj.Finger(card_index=10, is_revealed=True),
+                        sj.Finger(card_index=6, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
                 sj.Player(
                     score=0,
                     hand=(
-                        sj.Finger(card_index=10, is_revealed=True),
                         sj.Finger(card_index=1, is_revealed=True),
                         sj.Finger(card_index=9, is_revealed=True),
-                        sj.Finger(card_index=13, is_revealed=False),
-                        sj.Finger(card_index=12, is_revealed=False),
-                        sj.Finger(card_index=10, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=False),
-                        sj.Finger(card_index=12, is_revealed=False),
-                        sj.Finger(card_index=9, is_revealed=False),
-                        sj.Finger(card_index=5, is_revealed=False),
-                        sj.Finger(card_index=14, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=13, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
             ),
@@ -863,29 +849,24 @@ class TestGame:
 
     def test_with_card_replaced_with_discard_clear(self, rng: random.Random) -> None:
         game = sj.Game.new(players=2)
-        game = game.with_deal(
-            (1,)  # discard
-            + ((1, 1, 1) + (2, 2, 2) + (3, 3, 3) + (4, 4, 4))  # player 1
-            + ((5, 5, 5) + (6, 6, 6) + (7, 7, 7) + (8, 8, 8)),  # player 2
-        )
-        game = game.with_second_card_revealed(1)  # player 1
-        game = game.with_second_card_revealed(1)  # player 2
-        game = game.with_drawn_card(1)  # player 1
-        game = game.with_card_replaced_with_draw(2)  # player 1
+        game = game.with_deal((1, 1, 2))
+        game = game.with_second_card_revealed(1, 1)  # player 1
+        game = game.with_second_card_revealed(1, 2)  # player 2
+        game = game.with_card_replaced_with_discard(2, 0)  # player 1
         assert game == sj.Game(
             turn=3,
             state=sj.State.DRAW_OR_REPLACE_WITH_DISCARD,
             drawn_card_index=None,
             draw_pile=(
-                5,  # initial discard
-                10 - 5,
-                15 - 3,
+                5 - 1,
                 10 - 3,
-                10 - 3,
-                10 - 3,
-                10 - 3,
-                10 - 3,
-                10 - 3,
+                15 - 2,
+                10,
+                10,
+                10,
+                10,
+                10,
+                10,
                 10,
                 10,
                 10,
@@ -894,23 +875,23 @@ class TestGame:
                 10,
             ),
             discarded_card_index=1,
-            discard_pile=(0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            discard_pile=(1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
             players=(
                 sj.Player(
                     score=0,
                     hand=(
-                        sj.Finger(card_index=5, is_revealed=True),
-                        sj.Finger(card_index=5, is_revealed=True),
-                        sj.Finger(card_index=5, is_revealed=False),
-                        sj.Finger(card_index=6, is_revealed=False),
-                        sj.Finger(card_index=6, is_revealed=False),
-                        sj.Finger(card_index=6, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=False),
-                        sj.Finger(card_index=7, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
-                        sj.Finger(card_index=8, is_revealed=False),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
                 sj.Player(
@@ -919,28 +900,28 @@ class TestGame:
                         sj.Finger(card_index=None, is_revealed=True),
                         sj.Finger(card_index=None, is_revealed=True),
                         sj.Finger(card_index=None, is_revealed=True),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=2, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
-                        sj.Finger(card_index=3, is_revealed=False),
-                        sj.Finger(card_index=4, is_revealed=False),
-                        sj.Finger(card_index=4, is_revealed=False),
-                        sj.Finger(card_index=4, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
             ),
         )
 
-    def test_with_card_replaced_with_discard_win(self) -> None:
+    def test_with_card_replaced_with_discard_end(self) -> None:
         game = sj.Game(
             turn=100,
             state=sj.State.DRAW_OR_REPLACE_WITH_DISCARD,
             drawn_card_index=None,
             draw_pile=(
                 5 - 1,  # initial discard
-                10 - 2,
+                10 - 1,
                 15 - 2,
                 10 - 2,
                 10 - 2,
@@ -951,7 +932,7 @@ class TestGame:
                 10 - 2,
                 10 - 2,
                 10 - 2,
-                10 - 2,
+                10 - 1,
                 10,
                 10,
             ),
@@ -972,7 +953,7 @@ class TestGame:
                         sj.Finger(card_index=9, is_revealed=True),
                         sj.Finger(card_index=10, is_revealed=True),
                         sj.Finger(card_index=11, is_revealed=True),
-                        sj.Finger(card_index=12, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
                 sj.Player(
@@ -989,19 +970,19 @@ class TestGame:
                         sj.Finger(card_index=4, is_revealed=True),
                         sj.Finger(card_index=3, is_revealed=True),
                         sj.Finger(card_index=2, is_revealed=True),
-                        sj.Finger(card_index=1, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
             ),
         )
-        game = game.with_card_replaced_with_discard(11)
+        game = game.with_card_replaced_with_discard(11, 12)
         assert game == sj.Game(
             turn=101,
             state=sj.State.NULL,
             drawn_card_index=None,
             draw_pile=(
-                5 - 1,  # initial discard
-                10 - 2,
+                5 - 1,
+                10 - 1,
                 15 - 2,
                 10 - 2,
                 10 - 2,
@@ -1050,9 +1031,8 @@ class TestGame:
                         sj.Finger(card_index=4, is_revealed=True),
                         sj.Finger(card_index=3, is_revealed=True),
                         sj.Finger(card_index=2, is_revealed=True),
-                        sj.Finger(card_index=1, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
                     ),
                 ),
             ),
         )
-        assert game.winner_index == 0

--- a/tests/test_skyjo2.py
+++ b/tests/test_skyjo2.py
@@ -1036,3 +1036,495 @@ class TestGame:
                 ),
             ),
         )
+
+    def test_with_hidden_cards_revealed_tie(self) -> None:
+        game = sj.Game(
+            turn=100,
+            state=sj.State.NULL,
+            drawn_card_index=None,
+            draw_pile=(
+                5 - 1,  # initial discard
+                10 - 1,
+                15 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 2,
+                10,
+                10,
+            ),
+            discarded_card_index=0,
+            discard_pile=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            players=(
+                sj.Player(
+                    score=0,
+                    hand=(
+                        sj.Finger(card_index=1, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=3, is_revealed=True),
+                        sj.Finger(card_index=4, is_revealed=True),
+                        sj.Finger(card_index=5, is_revealed=True),
+                        sj.Finger(card_index=6, is_revealed=True),
+                        sj.Finger(card_index=7, is_revealed=True),
+                        sj.Finger(card_index=8, is_revealed=True),
+                        sj.Finger(card_index=9, is_revealed=True),
+                        sj.Finger(card_index=10, is_revealed=True),
+                        sj.Finger(card_index=11, is_revealed=True),
+                        sj.Finger(card_index=12, is_revealed=True),
+                    ),
+                ),
+                sj.Player(
+                    score=0,
+                    hand=(
+                        sj.Finger(card_index=12, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                    ),
+                ),
+            ),
+        )
+        game = game.with_hidden_cards_revealed((11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1))
+        assert game == sj.Game(
+            turn=100,
+            state=sj.State.NULL,
+            drawn_card_index=None,
+            draw_pile=(
+                5 - 1,  # initial discard
+                10 - 2,
+                15 - 2,
+                10 - 2,
+                10 - 2,
+                10 - 2,
+                10 - 2,
+                10 - 2,
+                10 - 2,
+                10 - 2,
+                10 - 2,
+                10 - 2,
+                10 - 2,
+                10,
+                10,
+            ),
+            discarded_card_index=0,
+            discard_pile=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            players=(
+                sj.Player(
+                    score=0,
+                    hand=(
+                        sj.Finger(card_index=1, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=3, is_revealed=True),
+                        sj.Finger(card_index=4, is_revealed=True),
+                        sj.Finger(card_index=5, is_revealed=True),
+                        sj.Finger(card_index=6, is_revealed=True),
+                        sj.Finger(card_index=7, is_revealed=True),
+                        sj.Finger(card_index=8, is_revealed=True),
+                        sj.Finger(card_index=9, is_revealed=True),
+                        sj.Finger(card_index=10, is_revealed=True),
+                        sj.Finger(card_index=11, is_revealed=True),
+                        sj.Finger(card_index=12, is_revealed=True),
+                    ),
+                ),
+                sj.Player(
+                    score=0,
+                    hand=(
+                        sj.Finger(card_index=12, is_revealed=True),
+                        sj.Finger(card_index=11, is_revealed=True),
+                        sj.Finger(card_index=10, is_revealed=True),
+                        sj.Finger(card_index=9, is_revealed=True),
+                        sj.Finger(card_index=8, is_revealed=True),
+                        sj.Finger(card_index=7, is_revealed=True),
+                        sj.Finger(card_index=6, is_revealed=True),
+                        sj.Finger(card_index=5, is_revealed=True),
+                        sj.Finger(card_index=4, is_revealed=True),
+                        sj.Finger(card_index=3, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=1, is_revealed=True),
+                    ),
+                ),
+            ),
+        )
+        assert game.final_scores == (54, 54)
+        assert game.players[0].hand_score == 54
+        assert game.players[1].hand_score == 54
+        assert game.winner_index == 0
+
+    def test_with_hidden_cards_revealed_lose(self) -> None:
+        game = sj.Game(
+            turn=100,
+            state=sj.State.NULL,
+            drawn_card_index=None,
+            draw_pile=(
+                5 - 1,  # initial discard
+                10 - 1,
+                15 - 2,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10,
+                10,
+            ),
+            discarded_card_index=0,
+            discard_pile=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            players=(
+                sj.Player(
+                    score=0,
+                    hand=(
+                        sj.Finger(card_index=1, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=3, is_revealed=True),
+                        sj.Finger(card_index=4, is_revealed=True),
+                        sj.Finger(card_index=5, is_revealed=True),
+                        sj.Finger(card_index=6, is_revealed=True),
+                        sj.Finger(card_index=7, is_revealed=True),
+                        sj.Finger(card_index=8, is_revealed=True),
+                        sj.Finger(card_index=9, is_revealed=True),
+                        sj.Finger(card_index=10, is_revealed=True),
+                        sj.Finger(card_index=11, is_revealed=True),
+                        sj.Finger(card_index=12, is_revealed=True),
+                    ),
+                ),
+                sj.Player(
+                    score=0,
+                    hand=(
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                    ),
+                ),
+            ),
+        )
+        game = game.with_hidden_cards_revealed((2,) * 11)
+        assert game == sj.Game(
+            turn=100,
+            state=sj.State.NULL,
+            drawn_card_index=None,
+            draw_pile=(
+                5 - 1,  # initial discard
+                10 - 1,
+                15 - 13,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10,
+                10,
+            ),
+            discarded_card_index=0,
+            discard_pile=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            players=(
+                sj.Player(
+                    score=0,
+                    hand=(
+                        sj.Finger(card_index=1, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=3, is_revealed=True),
+                        sj.Finger(card_index=4, is_revealed=True),
+                        sj.Finger(card_index=5, is_revealed=True),
+                        sj.Finger(card_index=6, is_revealed=True),
+                        sj.Finger(card_index=7, is_revealed=True),
+                        sj.Finger(card_index=8, is_revealed=True),
+                        sj.Finger(card_index=9, is_revealed=True),
+                        sj.Finger(card_index=10, is_revealed=True),
+                        sj.Finger(card_index=11, is_revealed=True),
+                        sj.Finger(card_index=12, is_revealed=True),
+                    ),
+                ),
+                sj.Player(
+                    score=0,
+                    hand=(
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                    ),
+                ),
+            ),
+        )
+        assert game.final_scores == (108, 0)
+        assert game.players[0].hand_score == 54
+        assert game.players[1].hand_score == 0
+        assert game.winner_index == 1
+
+    def test_with_hidden_cards_revealed_win(self) -> None:
+        game = sj.Game(
+            turn=100,
+            state=sj.State.NULL,
+            drawn_card_index=None,
+            draw_pile=(
+                5 - 1,  # initial discard
+                10 - 1,
+                15 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10,
+                10 - 1,
+            ),
+            discarded_card_index=0,
+            discard_pile=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            players=(
+                sj.Player(
+                    score=0,
+                    hand=(
+                        sj.Finger(card_index=1, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=3, is_revealed=True),
+                        sj.Finger(card_index=4, is_revealed=True),
+                        sj.Finger(card_index=5, is_revealed=True),
+                        sj.Finger(card_index=6, is_revealed=True),
+                        sj.Finger(card_index=7, is_revealed=True),
+                        sj.Finger(card_index=8, is_revealed=True),
+                        sj.Finger(card_index=9, is_revealed=True),
+                        sj.Finger(card_index=10, is_revealed=True),
+                        sj.Finger(card_index=11, is_revealed=True),
+                        sj.Finger(card_index=12, is_revealed=True),
+                    ),
+                ),
+                sj.Player(
+                    score=0,
+                    hand=(
+                        sj.Finger(card_index=14, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                    ),
+                ),
+            ),
+        )
+        game = game.with_hidden_cards_revealed((14,) * 5 + (13,) * 6)
+        assert game == sj.Game(
+            turn=100,
+            state=sj.State.NULL,
+            drawn_card_index=None,
+            draw_pile=(
+                5 - 1,  # initial discard
+                10 - 1,
+                15 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 6,
+                10 - 6,
+            ),
+            discarded_card_index=0,
+            discard_pile=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            players=(
+                sj.Player(
+                    score=0,
+                    hand=(
+                        sj.Finger(card_index=1, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=3, is_revealed=True),
+                        sj.Finger(card_index=4, is_revealed=True),
+                        sj.Finger(card_index=5, is_revealed=True),
+                        sj.Finger(card_index=6, is_revealed=True),
+                        sj.Finger(card_index=7, is_revealed=True),
+                        sj.Finger(card_index=8, is_revealed=True),
+                        sj.Finger(card_index=9, is_revealed=True),
+                        sj.Finger(card_index=10, is_revealed=True),
+                        sj.Finger(card_index=11, is_revealed=True),
+                        sj.Finger(card_index=12, is_revealed=True),
+                    ),
+                ),
+                sj.Player(
+                    score=0,
+                    hand=(
+                        sj.Finger(card_index=14, is_revealed=True),
+                        sj.Finger(card_index=14, is_revealed=True),
+                        sj.Finger(card_index=14, is_revealed=True),
+                        sj.Finger(card_index=14, is_revealed=True),
+                        sj.Finger(card_index=14, is_revealed=True),
+                        sj.Finger(card_index=14, is_revealed=True),
+                        sj.Finger(card_index=13, is_revealed=True),
+                        sj.Finger(card_index=13, is_revealed=True),
+                        sj.Finger(card_index=13, is_revealed=True),
+                        sj.Finger(card_index=13, is_revealed=True),
+                        sj.Finger(card_index=13, is_revealed=True),
+                        sj.Finger(card_index=13, is_revealed=True),
+                    ),
+                ),
+            ),
+        )
+        assert game.final_scores == (54, 138)
+        assert game.players[0].hand_score == 54
+        assert game.players[1].hand_score == 138
+        assert game.winner_index == 0
+
+    def test_with_random_hidden_cards_revealed(self, rng: random.Random) -> None:
+        game = sj.Game(
+            turn=100,
+            state=sj.State.NULL,
+            drawn_card_index=None,
+            draw_pile=(
+                5 - 1,  # initial discard
+                10 - 1,
+                15 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 1,
+                10 - 2,
+                10,
+                10,
+            ),
+            discarded_card_index=0,
+            discard_pile=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            players=(
+                sj.Player(
+                    score=0,
+                    hand=(
+                        sj.Finger(card_index=1, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=3, is_revealed=True),
+                        sj.Finger(card_index=4, is_revealed=True),
+                        sj.Finger(card_index=5, is_revealed=True),
+                        sj.Finger(card_index=6, is_revealed=True),
+                        sj.Finger(card_index=7, is_revealed=True),
+                        sj.Finger(card_index=8, is_revealed=True),
+                        sj.Finger(card_index=9, is_revealed=True),
+                        sj.Finger(card_index=10, is_revealed=True),
+                        sj.Finger(card_index=11, is_revealed=True),
+                        sj.Finger(card_index=12, is_revealed=True),
+                    ),
+                ),
+                sj.Player(
+                    score=0,
+                    hand=(
+                        sj.Finger(card_index=12, is_revealed=True),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                        sj.Finger(card_index=None, is_revealed=False),
+                    ),
+                ),
+            ),
+        )
+        game = game.with_random_hidden_cards_revealed(rng=rng)
+        assert game == sj.Game(
+            turn=100,
+            state=sj.State.NULL,
+            drawn_card_index=None,
+            draw_pile=(4, 8, 14, 9, 9, 8, 9, 8, 7, 9, 8, 8, 7, 10, 7),
+            discarded_card_index=0,
+            discard_pile=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            players=(
+                sj.Player(
+                    score=0,
+                    hand=(
+                        sj.Finger(card_index=1, is_revealed=True),
+                        sj.Finger(card_index=2, is_revealed=True),
+                        sj.Finger(card_index=3, is_revealed=True),
+                        sj.Finger(card_index=4, is_revealed=True),
+                        sj.Finger(card_index=5, is_revealed=True),
+                        sj.Finger(card_index=6, is_revealed=True),
+                        sj.Finger(card_index=7, is_revealed=True),
+                        sj.Finger(card_index=8, is_revealed=True),
+                        sj.Finger(card_index=9, is_revealed=True),
+                        sj.Finger(card_index=10, is_revealed=True),
+                        sj.Finger(card_index=11, is_revealed=True),
+                        sj.Finger(card_index=12, is_revealed=True),
+                    ),
+                ),
+                sj.Player(
+                    score=0,
+                    hand=(
+                        sj.Finger(card_index=12, is_revealed=True),
+                        sj.Finger(card_index=10, is_revealed=True),
+                        sj.Finger(card_index=12, is_revealed=True),
+                        sj.Finger(card_index=1, is_revealed=True),
+                        sj.Finger(card_index=7, is_revealed=True),
+                        sj.Finger(card_index=14, is_revealed=True),
+                        sj.Finger(card_index=14, is_revealed=True),
+                        sj.Finger(card_index=11, is_revealed=True),
+                        sj.Finger(card_index=8, is_revealed=True),
+                        sj.Finger(card_index=14, is_revealed=True),
+                        sj.Finger(card_index=5, is_revealed=True),
+                        sj.Finger(card_index=8, is_revealed=True),
+                    ),
+                ),
+            ),
+        )
+        assert game.final_scores == (54, 92)
+        assert game.players[0].hand_score == 54
+        assert game.players[1].hand_score == 92
+        assert game.winner_index == 0

--- a/tests/test_skyjo2_play.py
+++ b/tests/test_skyjo2_play.py
@@ -37,55 +37,56 @@ def test_play_two(rng: random.Random) -> None:
     # 2 (reveal)
     # 2 players * 9 cards * 2 actions (draws + replaces)
     # 2 actions (winning draw + replace)
-    assert len(replay) == 42
+    # 1 (reveal hidden cards)
+    assert len(replay) == 43
     result = replay[-1]
     assert result == sj.Game(
         turn=22,
-        state=sj.State.NULL,
+        state=sj.State.ENDED,
         drawn_card_index=None,
         draw_pile=(4, 7, 11, 7, 7, 8, 8, 5, 6, 5, 7, 10, 7, 8, 6),
-        discarded_card_index=3,
-        discard_pile=(0, 0, 3, 0, 1, 1, 1, 2, 2, 3, 1, 0, 2, 1, 2),
+        discarded_card_index=2,
+        discard_pile=(0, 2, 1, 2, 0, 1, 1, 2, 3, 3, 1, 0, 1, 0, 2),
         players=(
             sj.Player(
                 score=0,
                 hand=(
-                    sj.Finger(card_index=10, is_revealed=True),
                     sj.Finger(card_index=1, is_revealed=True),
-                    sj.Finger(card_index=5, is_revealed=True),
-                    sj.Finger(card_index=4, is_revealed=True),
-                    sj.Finger(card_index=10, is_revealed=True),
-                    sj.Finger(card_index=3, is_revealed=True),
-                    sj.Finger(card_index=7, is_revealed=True),
-                    sj.Finger(card_index=14, is_revealed=True),
-                    sj.Finger(card_index=4, is_revealed=True),
                     sj.Finger(card_index=13, is_revealed=True),
-                    sj.Finger(card_index=0, is_revealed=True),
                     sj.Finger(card_index=12, is_revealed=True),
+                    sj.Finger(card_index=9, is_revealed=True),
+                    sj.Finger(card_index=7, is_revealed=True),
+                    sj.Finger(card_index=4, is_revealed=True),
+                    sj.Finger(card_index=9, is_revealed=True),
+                    sj.Finger(card_index=5, is_revealed=True),
+                    sj.Finger(card_index=10, is_revealed=True),
+                    sj.Finger(card_index=7, is_revealed=True),
+                    sj.Finger(card_index=4, is_revealed=True),
+                    sj.Finger(card_index=0, is_revealed=True),
                 ),
             ),
             sj.Player(
                 score=0,
                 hand=(
-                    sj.Finger(card_index=7, is_revealed=True),
-                    sj.Finger(card_index=3, is_revealed=True),
+                    sj.Finger(card_index=10, is_revealed=True),
                     sj.Finger(card_index=6, is_revealed=True),
-                    sj.Finger(card_index=9, is_revealed=True),
-                    sj.Finger(card_index=14, is_revealed=True),
-                    sj.Finger(card_index=8, is_revealed=True),
                     sj.Finger(card_index=7, is_revealed=True),
-                    sj.Finger(card_index=8, is_revealed=True),
-                    sj.Finger(card_index=1, is_revealed=True),
-                    sj.Finger(card_index=9, is_revealed=True),
+                    sj.Finger(card_index=14, is_revealed=True),
                     sj.Finger(card_index=2, is_revealed=True),
-                    sj.Finger(card_index=1, is_revealed=False),
+                    sj.Finger(card_index=2, is_revealed=True),
+                    sj.Finger(card_index=8, is_revealed=True),
+                    sj.Finger(card_index=4, is_revealed=True),
+                    sj.Finger(card_index=3, is_revealed=True),
+                    sj.Finger(card_index=14, is_revealed=True),
+                    sj.Finger(card_index=13, is_revealed=True),
+                    sj.Finger(card_index=12, is_revealed=True),
                 ),
             ),
         ),
     )
-    assert result.players[0].hand_score == 59
-    assert result.players[1].hand_score == 51
-    assert result.final_scores == (59 * 2, 51)
+    assert result.players[0].hand_score == 57
+    assert result.players[1].hand_score == 71
+    assert result.final_scores == (57, 71)
 
 
 def test_play_three(rng: random.Random) -> None:
@@ -95,73 +96,74 @@ def test_play_three(rng: random.Random) -> None:
     # 3 (reveal)
     # 3 players * 9 cards * 2 actions (draws + replaces)
     # 2 actions (winning draw + replace)
-    assert len(replay) == 61
+    # 1 (reveal hidden cards)
+    assert len(replay) == 62
     result = replay[-1]
     assert result == sj.Game(
         turn=32,
-        state=sj.State.NULL,
+        state=sj.State.ENDED,
         drawn_card_index=None,
         draw_pile=(3, 6, 10, 6, 4, 7, 6, 5, 6, 4, 6, 6, 5, 8, 3),
-        discarded_card_index=3,
-        discard_pile=(0, 0, 3, 1, 2, 1, 1, 4, 3, 4, 2, 0, 2, 1, 4),
+        discarded_card_index=2,
+        discard_pile=(0, 2, 2, 3, 1, 2, 2, 2, 3, 3, 0, 2, 1, 0, 5),
         players=(
             sj.Player(
                 score=0,
                 hand=(
-                    sj.Finger(card_index=10, is_revealed=True),
                     sj.Finger(card_index=1, is_revealed=True),
-                    sj.Finger(card_index=4, is_revealed=True),
-                    sj.Finger(card_index=9, is_revealed=True),
                     sj.Finger(card_index=12, is_revealed=True),
-                    sj.Finger(card_index=14, is_revealed=True),
-                    sj.Finger(card_index=0, is_revealed=True),
-                    sj.Finger(card_index=5, is_revealed=True),
-                    sj.Finger(card_index=6, is_revealed=True),
-                    sj.Finger(card_index=3, is_revealed=True),
-                    sj.Finger(card_index=4, is_revealed=True),
-                    sj.Finger(card_index=10, is_revealed=True),
-                ),
-            ),
-            sj.Player(
-                score=0,
-                hand=(
                     sj.Finger(card_index=7, is_revealed=True),
+                    sj.Finger(card_index=7, is_revealed=True),
+                    sj.Finger(card_index=2, is_revealed=True),
+                    sj.Finger(card_index=5, is_revealed=True),
                     sj.Finger(card_index=3, is_revealed=True),
-                    sj.Finger(card_index=1, is_revealed=True),
+                    sj.Finger(card_index=4, is_revealed=True),
+                    sj.Finger(card_index=12, is_revealed=True),
                     sj.Finger(card_index=0, is_revealed=True),
                     sj.Finger(card_index=6, is_revealed=True),
-                    sj.Finger(card_index=12, is_revealed=True),
-                    sj.Finger(card_index=11, is_revealed=True),
                     sj.Finger(card_index=4, is_revealed=True),
-                    sj.Finger(card_index=14, is_revealed=True),
-                    sj.Finger(card_index=11, is_revealed=True),
-                    sj.Finger(card_index=2, is_revealed=True),
-                    sj.Finger(card_index=1, is_revealed=False),
                 ),
             ),
             sj.Player(
                 score=0,
                 hand=(
-                    sj.Finger(card_index=5, is_revealed=True),
                     sj.Finger(card_index=6, is_revealed=True),
-                    sj.Finger(card_index=13, is_revealed=True),
-                    sj.Finger(card_index=2, is_revealed=True),
-                    sj.Finger(card_index=12, is_revealed=True),
-                    sj.Finger(card_index=11, is_revealed=True),
+                    sj.Finger(card_index=10, is_revealed=True),
                     sj.Finger(card_index=9, is_revealed=True),
-                    sj.Finger(card_index=14, is_revealed=True),
+                    sj.Finger(card_index=2, is_revealed=True),
+                    sj.Finger(card_index=9, is_revealed=True),
+                    sj.Finger(card_index=4, is_revealed=True),
+                    sj.Finger(card_index=7, is_revealed=True),
+                    sj.Finger(card_index=13, is_revealed=True),
+                    sj.Finger(card_index=12, is_revealed=True),
+                    sj.Finger(card_index=9, is_revealed=True),
                     sj.Finger(card_index=1, is_revealed=True),
+                    sj.Finger(card_index=11, is_revealed=True),
+                ),
+            ),
+            sj.Player(
+                score=0,
+                hand=(
+                    sj.Finger(card_index=10, is_revealed=True),
+                    sj.Finger(card_index=13, is_revealed=True),
+                    sj.Finger(card_index=14, is_revealed=True),
+                    sj.Finger(card_index=4, is_revealed=True),
+                    sj.Finger(card_index=8, is_revealed=True),
+                    sj.Finger(card_index=10, is_revealed=True),
+                    sj.Finger(card_index=14, is_revealed=True),
+                    sj.Finger(card_index=0, is_revealed=True),
+                    sj.Finger(card_index=12, is_revealed=True),
                     sj.Finger(card_index=4, is_revealed=True),
                     sj.Finger(card_index=11, is_revealed=True),
-                    sj.Finger(card_index=8, is_revealed=False),
+                    sj.Finger(card_index=10, is_revealed=True),
                 ),
             ),
         ),
     )
-    assert result.players[0].hand_score == 54
-    assert result.players[1].hand_score == 48
-    assert result.players[2].hand_score == 72
-    assert result.final_scores == (54 * 2, 48, 72)
+    assert result.players[0].hand_score == 39
+    assert result.players[1].hand_score == 69
+    assert result.players[2].hand_score == 86
+    assert result.final_scores == (39, 69, 86)
 
 
 def test_play_forfeit(rng: random.Random) -> None:
@@ -178,50 +180,53 @@ def test_play_forfeit(rng: random.Random) -> None:
     # 1 player * 5 cards * 2 actions (draws + replaces)
     # 1 player * 5 actions (replace with discard)
     # 1 forefit
-    assert len(replay) == 20
+    # 1 (reveal hidden cards)
+    assert len(replay) == 21
     result = replay[-1]
     assert result == sj.Game(
         turn=13,
-        state=sj.State.NULL,
+        state=sj.State.FORFEITED,
         drawn_card_index=None,
         draw_pile=(5, 8, 12, 8, 8, 8, 8, 7, 8, 6, 7, 10, 8, 9, 8),
         discarded_card_index=2,
-        discard_pile=(0, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0),
+        discard_pile=(0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0, 0, 1, 0, 1),
         players=(
             sj.Player(
                 score=0,
                 hand=(
-                    sj.Finger(card_index=10, is_revealed=True),
                     sj.Finger(card_index=1, is_revealed=True),
+                    sj.Finger(card_index=13, is_revealed=True),
+                    sj.Finger(card_index=7, is_revealed=True),
+                    sj.Finger(card_index=7, is_revealed=True),
+                    sj.Finger(card_index=4, is_revealed=True),
                     sj.Finger(card_index=8, is_revealed=True),
-                    sj.Finger(card_index=13, is_revealed=False),
-                    sj.Finger(card_index=12, is_revealed=False),
-                    sj.Finger(card_index=10, is_revealed=False),
-                    sj.Finger(card_index=7, is_revealed=False),
-                    sj.Finger(card_index=12, is_revealed=False),
-                    sj.Finger(card_index=9, is_revealed=False),
-                    sj.Finger(card_index=5, is_revealed=False),
-                    sj.Finger(card_index=14, is_revealed=False),
-                    sj.Finger(card_index=3, is_revealed=False),
+                    sj.Finger(card_index=2, is_revealed=True),
+                    sj.Finger(card_index=2, is_revealed=True),
+                    sj.Finger(card_index=9, is_revealed=True),
+                    sj.Finger(card_index=14, is_revealed=True),
+                    sj.Finger(card_index=8, is_revealed=True),
+                    sj.Finger(card_index=1, is_revealed=True),
                 ),
             ),
             sj.Player(
                 score=0,
                 hand=(
-                    sj.Finger(card_index=7, is_revealed=True),
+                    sj.Finger(card_index=10, is_revealed=True),
+                    sj.Finger(card_index=6, is_revealed=True),
+                    sj.Finger(card_index=10, is_revealed=True),
+                    sj.Finger(card_index=12, is_revealed=True),
+                    sj.Finger(card_index=5, is_revealed=True),
+                    sj.Finger(card_index=3, is_revealed=True),
                     sj.Finger(card_index=3, is_revealed=True),
                     sj.Finger(card_index=5, is_revealed=True),
                     sj.Finger(card_index=6, is_revealed=True),
                     sj.Finger(card_index=4, is_revealed=True),
                     sj.Finger(card_index=9, is_revealed=True),
                     sj.Finger(card_index=10, is_revealed=True),
-                    sj.Finger(card_index=2, is_revealed=False),
-                    sj.Finger(card_index=9, is_revealed=False),
-                    sj.Finger(card_index=14, is_revealed=False),
-                    sj.Finger(card_index=8, is_revealed=False),
-                    sj.Finger(card_index=1, is_revealed=False),
                 ),
             ),
         ),
     )
-    assert result.is_forfeit
+    assert result.players[0].hand_score == 52
+    assert result.players[1].hand_score == 59
+    assert result.final_scores == (52 * 2, 59)


### PR DESCRIPTION
Player hands are no longer pre-dealt. Instead, cards are drawn to fill player hands on-demand. Therefore:

* The initial deal resolves only the top left card in each player's hand
* State transitions that certainly reveal a new card now accept `revealed_card: int` and have a `*_random_*` variant that accepts an `rng: random.Random` used to select it.
* State transitions that may reveal a card (replaces) no accept `revealed_card: int | None`, expecting `int` when the replaced card is currently hidden and `None` when it is not. These methods also have a `*_random_*` variant.
* I added a new state transition `with_hidden_cards_revealed` (and a `_random_` variant). I also renamed some existing states for clarity and fixed a bunch of tests.

I got distracted debugging and also made it so each transition method no longer refers to `self`. This avoids issues where we accidentally refer to the `self.*` version of an attribute that might be out of date.