### PR TITLE
fix: Fix foreit condition, final_score_differntials, and equal score doubling

### DIFF
--- a/src/skyjo2/__init__.py
+++ b/src/skyjo2/__init__.py
@@ -607,12 +607,12 @@ class Game(NamedTuple):
 
         # Check if the current player won. If so, stop the game. Otherwise,
         # rotate players so the next is in the first slot.
+        turn += 1
         if players[0].is_hand_revealed:
             state = State.ENDED
         else:
             players = (*players[1:], players[0])
             state = State.DRAW_OR_REPLACE_WITH_DISCARD
-            turn += 1
 
         return Game(
             turn=turn,
@@ -699,12 +699,12 @@ class Game(NamedTuple):
 
         # Check if the current player won. If so, stop the game. Otherwise,
         # rotate players so the next is in the first slot.
+        turn += 1
         if players[0].is_hand_revealed:
             state = State.ENDED
         else:
             players = (*players[1:], players[0])
             state = State.DRAW_OR_REPLACE_WITH_DISCARD
-            turn += 1
 
         return Game(
             turn=turn,
@@ -787,12 +787,12 @@ class Game(NamedTuple):
 
         # Check if the current player won. If so, stop the game. Otherwise,
         # rotate players so the next is in the first slot.
+        turn += 1
         if players[0].is_hand_revealed:
             state = State.ENDED
         else:
             players = (*players[1:], players[0])
             state = State.DRAW_OR_REPLACE_WITH_DISCARD
-            turn += 1
 
         return Game(
             turn=turn,

--- a/src/skyjo2/__init__.py
+++ b/src/skyjo2/__init__.py
@@ -293,7 +293,7 @@ class Game(NamedTuple):
 
         # Penalize the round ender if they forfeited or didn't have the lowest
         # hand score across all players.
-        if self.state == State.FORFEITED or scores[0] > min(scores[1:]):
+        if self.state == State.FORFEITED or scores[0] >= min(scores[1:]):
             scores[0] *= 2
 
         return tuple(scores)
@@ -304,7 +304,7 @@ class Game(NamedTuple):
 
         final_scores = self.final_scores  # don't recompute
         winner_final_score = min(final_scores)
-        return tuple(score - winner_final_score for score in winner_final_score)
+        return tuple(score - winner_final_score for score in final_scores)
 
     @property
     def winner(self) -> Player:

--- a/src/skyjo2/play.py
+++ b/src/skyjo2/play.py
@@ -89,10 +89,11 @@ def play(
 
     assert 2 <= len(players) <= 8
 
-    # Keep track of completed turns in the main round and the last turn on
-    # which each player revealed or replaced a new card.
-    player_round_turn_counts = [0] * len(players)
-    last_progress_round_turn_counts = [0] * len(players)
+    # Keep track of the raw turn index on which each player last revealed or
+    # replaced a new card. This mirrors the current `skyjo.game` approach,
+    # where no-progress is measured in "times this player has come around
+    # again" via integer division by player count.
+    last_progress_turns = [0] * len(players)
 
     game = Game.new(players=len(players))
     yield game
@@ -103,17 +104,6 @@ def play(
     while not game.is_ended_or_forfeited:
         turn = game.turn
         player_index = turn % len(players)
-
-        if (
-            no_progress_turn_max is not None
-            and game.state != State.REVEAL_SECOND_CARD
-            and player_round_turn_counts[player_index]
-            - last_progress_round_turn_counts[player_index]
-            > no_progress_turn_max
-        ):
-            game = game.with_forfeit()
-            yield game
-            break
 
         player_hand_revealed_count = game.player.hand_revealed_count
 
@@ -163,14 +153,17 @@ def play(
 
         turn_completed = game.turn > turn
         if turn_completed and turn >= len(players):
-            player_round_turn_counts[player_index] += 1
             acting_player = (
                 game.player if game.is_ended_or_forfeited else game.players[-1]
             )
             if acting_player.hand_revealed_count > player_hand_revealed_count:
-                last_progress_round_turn_counts[player_index] = (
-                    player_round_turn_counts[player_index]
-                )
+                last_progress_turns[player_index] = turn
+            elif (
+                no_progress_turn_max is not None
+                and (turn - last_progress_turns[player_index]) // len(players)
+                > no_progress_turn_max
+            ):
+                game = game.with_forfeit()
 
         yield game
 

--- a/src/skyjo2/play.py
+++ b/src/skyjo2/play.py
@@ -89,8 +89,10 @@ def play(
 
     assert 2 <= len(players) <= 8
 
-    # Keep track of the last time the player revealed or replaced a new card.
-    last_progress_turns = [0] * len(players)
+    # Keep track of completed turns in the main round and the last turn on
+    # which each player revealed or replaced a new card.
+    player_round_turn_counts = [0] * len(players)
+    last_progress_round_turn_counts = [0] * len(players)
 
     game = Game.new(players=len(players))
     yield game
@@ -101,6 +103,18 @@ def play(
     while not game.is_ended_or_forfeited:
         turn = game.turn
         player_index = turn % len(players)
+
+        if (
+            no_progress_turn_max is not None
+            and game.state != State.REVEAL_SECOND_CARD
+            and player_round_turn_counts[player_index]
+            - last_progress_round_turn_counts[player_index]
+            > no_progress_turn_max
+        ):
+            game = game.with_forfeit()
+            yield game
+            break
+
         player_hand_revealed_count = game.player.hand_revealed_count
 
         action = players[player_index].play(game)
@@ -147,23 +161,18 @@ def play(
             case _, _:
                 raise Rule(f"Invalid action {action} for game {game}")
 
-        # Check if the player revealed any new cards. Don't forget to account
-        # for the player list rotating as the game state iterates.
-        if game.players[-1].hand_revealed_count > player_hand_revealed_count:
-            last_progress_turns[player_index] = turn
+        turn_completed = game.turn > turn
+        if turn_completed and turn >= len(players):
+            player_round_turn_counts[player_index] += 1
+            acting_player = (
+                game.player if game.is_ended_or_forfeited else game.players[-1]
+            )
+            if acting_player.hand_revealed_count > player_hand_revealed_count:
+                last_progress_round_turn_counts[player_index] = (
+                    player_round_turn_counts[player_index]
+                )
 
         yield game
-
-        # Check if the current player has exceeded the limit for turns without
-        # making progress, and if so, forfeit. Doing so sets the game's state
-        # to `State.NULL`, meaning we don't have to break.
-        if no_progress_turn_max is not None:
-            turn_per_player = turn // len(players)
-            no_progress_turn_count = last_progress_turns[player_index] - turn_per_player
-            if no_progress_turn_count > no_progress_turn_max:
-                game = game.with_forfeit()
-                yield game
-                break
 
     # Reveal all hidden cards.
     game = game.with_random_hidden_cards_revealed(rng=rng)

--- a/tests/test_skyjo2.py
+++ b/tests/test_skyjo2.py
@@ -1159,10 +1159,11 @@ class TestGame:
                 ),
             ),
         )
-        assert game.final_scores == (54, 54)
+        assert game.final_scores == (108, 54)
+        assert game.final_score_differentials == (54, 0)
         assert game.players[0].hand_score == 54
         assert game.players[1].hand_score == 54
-        assert game.winner_index == 0
+        assert game.winner_index == 1
 
     def test_with_hidden_cards_revealed_lose(self) -> None:
         game = sj.Game(

--- a/tests/test_skyjo2_play.py
+++ b/tests/test_skyjo2_play.py
@@ -177,35 +177,35 @@ def test_play_forfeit(rng: random.Random) -> None:
     # 1 (new)
     # 1 (deal)
     # 2 (reveal)
-    # 1 player * 5 cards * 2 actions (draws + replaces)
-    # 1 player * 5 actions (replace with discard)
+    # 1 player * 8 cards * 2 actions (draws + replaces)
+    # 1 player * 8 actions (replace with discard)
     # 1 forefit
     # 1 (reveal hidden cards)
-    assert len(replay) == 21
+    assert len(replay) == 27
     result = replay[-1]
     assert result == sj.Game(
-        turn=13,
+        turn=17,
         state=sj.State.FORFEITED,
         drawn_card_index=None,
-        draw_pile=(5, 8, 12, 8, 8, 8, 8, 7, 8, 6, 7, 10, 8, 9, 8),
+        draw_pile=(5, 8, 12, 7, 8, 8, 8, 7, 8, 6, 7, 10, 8, 9, 7),
         discarded_card_index=2,
-        discard_pile=(0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0, 0, 1, 0, 1),
+        discard_pile=(0, 0, 1, 0, 0, 0, 0, 2, 0, 2, 0, 0, 1, 0, 1),
         players=(
             sj.Player(
                 score=0,
                 hand=(
                     sj.Finger(card_index=1, is_revealed=True),
                     sj.Finger(card_index=13, is_revealed=True),
-                    sj.Finger(card_index=7, is_revealed=True),
-                    sj.Finger(card_index=7, is_revealed=True),
                     sj.Finger(card_index=4, is_revealed=True),
-                    sj.Finger(card_index=8, is_revealed=True),
-                    sj.Finger(card_index=2, is_revealed=True),
                     sj.Finger(card_index=2, is_revealed=True),
                     sj.Finger(card_index=9, is_revealed=True),
                     sj.Finger(card_index=14, is_revealed=True),
                     sj.Finger(card_index=8, is_revealed=True),
                     sj.Finger(card_index=1, is_revealed=True),
+                    sj.Finger(card_index=5, is_revealed=True),
+                    sj.Finger(card_index=6, is_revealed=True),
+                    sj.Finger(card_index=4, is_revealed=True),
+                    sj.Finger(card_index=9, is_revealed=True),
                 ),
             ),
             sj.Player(
@@ -218,15 +218,15 @@ def test_play_forfeit(rng: random.Random) -> None:
                     sj.Finger(card_index=5, is_revealed=True),
                     sj.Finger(card_index=3, is_revealed=True),
                     sj.Finger(card_index=3, is_revealed=True),
-                    sj.Finger(card_index=5, is_revealed=True),
-                    sj.Finger(card_index=6, is_revealed=True),
-                    sj.Finger(card_index=4, is_revealed=True),
-                    sj.Finger(card_index=9, is_revealed=True),
+                    sj.Finger(card_index=7, is_revealed=True),
+                    sj.Finger(card_index=8, is_revealed=True),
                     sj.Finger(card_index=10, is_revealed=True),
+                    sj.Finger(card_index=14, is_revealed=True),
+                    sj.Finger(card_index=3, is_revealed=True),
                 ),
             ),
         ),
     )
     assert result.players[0].hand_score == 52
-    assert result.players[1].hand_score == 59
-    assert result.final_scores == (52 * 2, 59)
+    assert result.players[1].hand_score == 67
+    assert result.final_scores == (52 * 2, 67)

--- a/tests/test_skyjo2_play.py
+++ b/tests/test_skyjo2_play.py
@@ -177,37 +177,20 @@ def test_play_forfeit(rng: random.Random) -> None:
     # 1 (new)
     # 1 (deal)
     # 2 (reveal)
-    # 1 player * 8 cards * 2 actions (draws + replaces)
-    # 1 player * 8 actions (replace with discard)
+    # 1 player * 7 cards * 2 actions (draws + replaces)
+    # 1 player * 7 actions (replace with discard)
     # 1 forefit
     # 1 (reveal hidden cards)
-    assert len(replay) == 27
+    assert len(replay) == 24
     result = replay[-1]
     assert result == sj.Game(
-        turn=17,
+        turn=16,
         state=sj.State.FORFEITED,
         drawn_card_index=None,
-        draw_pile=(5, 8, 12, 7, 8, 8, 8, 7, 8, 6, 7, 10, 8, 9, 7),
+        draw_pile=(5, 8, 12, 8, 8, 8, 8, 7, 8, 6, 7, 10, 8, 9, 7),
         discarded_card_index=2,
-        discard_pile=(0, 0, 1, 0, 0, 0, 0, 2, 0, 2, 0, 0, 1, 0, 1),
+        discard_pile=(0, 0, 0, 0, 0, 0, 0, 2, 0, 2, 0, 0, 1, 0, 1),
         players=(
-            sj.Player(
-                score=0,
-                hand=(
-                    sj.Finger(card_index=1, is_revealed=True),
-                    sj.Finger(card_index=13, is_revealed=True),
-                    sj.Finger(card_index=4, is_revealed=True),
-                    sj.Finger(card_index=2, is_revealed=True),
-                    sj.Finger(card_index=9, is_revealed=True),
-                    sj.Finger(card_index=14, is_revealed=True),
-                    sj.Finger(card_index=8, is_revealed=True),
-                    sj.Finger(card_index=1, is_revealed=True),
-                    sj.Finger(card_index=5, is_revealed=True),
-                    sj.Finger(card_index=6, is_revealed=True),
-                    sj.Finger(card_index=4, is_revealed=True),
-                    sj.Finger(card_index=9, is_revealed=True),
-                ),
-            ),
             sj.Player(
                 score=0,
                 hand=(
@@ -220,13 +203,30 @@ def test_play_forfeit(rng: random.Random) -> None:
                     sj.Finger(card_index=3, is_revealed=True),
                     sj.Finger(card_index=7, is_revealed=True),
                     sj.Finger(card_index=8, is_revealed=True),
+                    sj.Finger(card_index=2, is_revealed=True),
+                    sj.Finger(card_index=2, is_revealed=True),
+                    sj.Finger(card_index=9, is_revealed=True),
+                ),
+            ),
+            sj.Player(
+                score=0,
+                hand=(
+                    sj.Finger(card_index=1, is_revealed=True),
+                    sj.Finger(card_index=13, is_revealed=True),
+                    sj.Finger(card_index=4, is_revealed=True),
+                    sj.Finger(card_index=14, is_revealed=True),
+                    sj.Finger(card_index=8, is_revealed=True),
+                    sj.Finger(card_index=1, is_revealed=True),
+                    sj.Finger(card_index=5, is_revealed=True),
+                    sj.Finger(card_index=6, is_revealed=True),
+                    sj.Finger(card_index=4, is_revealed=True),
+                    sj.Finger(card_index=9, is_revealed=True),
                     sj.Finger(card_index=10, is_revealed=True),
                     sj.Finger(card_index=14, is_revealed=True),
-                    sj.Finger(card_index=3, is_revealed=True),
                 ),
             ),
         ),
     )
-    assert result.players[0].hand_score == 52
-    assert result.players[1].hand_score == 67
-    assert result.final_scores == (52 * 2, 67)
+    assert result.players[0].hand_score == 53
+    assert result.players[1].hand_score == 65
+    assert result.final_scores == (53 * 2, 65)


### PR DESCRIPTION
Issues flagged by AI and fixed by it too, but seemed right to me:
- forfeit condition and turn compute was wrong
- score computation should double when round ender has equal score to someone else too (rules are that you must have distinct minimum)
- score differntial iterates over scores iterable not just winer score (int)